### PR TITLE
Issue#32 - isPiece flag on folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "esbuild src/plugin.ts --bundle --outfile=dist/hytale_plugin.js",
     "dev": "esbuild src/plugin.ts --bundle --outfile=dist/hytale_plugin.js --watch"
   },
-  "author": "JannisX11",
+  "author": "JannisX11, Kanno",
   "license": "MIT",
   "dependencies": {
     "blockbench-types": "^5.0.0"

--- a/src/blockymodel.ts
+++ b/src/blockymodel.ts
@@ -57,6 +57,10 @@ type CubeHytale = Cube & {
 	double_sided: boolean
 }
 
+type GroupHytale = Group & {
+	isPiece: boolean
+}
+
 interface CompileOptions {
 	attachment?: Collection,
 	raw?: boolean
@@ -315,7 +319,7 @@ export function setupBlockymodelCodec(): Codec {
 						offset: formatVector([0, 0, 0]),
 						stretch: formatVector([0, 0, 0]),
 						settings: {
-							isPiece: false
+							isPiece: (element instanceof Group && (element as GroupHytale).isPiece) || false
 						},
 						textureLayout: {},
 						unwrapMode: "custom",
@@ -375,9 +379,9 @@ export function setupBlockymodelCodec(): Codec {
 			function parseNode(node: BlockymodelNode, parent_node: BlockymodelNode | null, parent_group: Group | 'root' = 'root', parent_offset?: ArrayVector3) {
 				
 				if (args.attachment) {
-					// Attach
+					// Attach groups marked with isPiece: true to matching bones in main model
 					let attachment_node: Group | undefined;
-					if (args.attachment && node.shape?.type == 'none' && existing_groups.length) {
+					if (args.attachment && node.shape?.settings?.isPiece === true && existing_groups.length) {
 						let node_name = node.name;
 						attachment_node = existing_groups.find(g => g.name == node_name);
 					}
@@ -429,6 +433,9 @@ export function setupBlockymodelCodec(): Codec {
 					}
 
 					group.init();
+					group.extend({
+						isPiece: node.shape?.settings?.isPiece ?? false,
+					});
 				}
 
 

--- a/src/element.ts
+++ b/src/element.ts
@@ -34,6 +34,17 @@ export function setupElements() {
 	});
 	track(property_double_sided);
 
+	let property_isPiece = new Property(Group, 'boolean', 'isPiece', {
+		condition: {formats: FORMAT_IDS},
+		inputs: {
+			element_panel: {
+				input: {label: 'isPiece', type: 'checkbox'},
+				onChange() {}
+			}
+		}
+	});
+	track(property_isPiece);
+
 	let add_quad_action = new Action('hytale_add_quad', {
 		name: 'Add Quad',
 		icon: 'highlighter_size_5',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,7 +10,7 @@ import { setupPhotoshopTools } from "./photoshop_copy_paste";
 
 BBPlugin.register('hytale_plugin', {
     title: 'Hytale Models',
-    author: 'JannisX11',
+    author: 'JannisX11, Kanno',
     icon: 'icon.png',
     version: Package.version,
     description: 'Adds support for creating models and animations for Hytale',


### PR DESCRIPTION
This PR fixes the issue reported in Issue #32

Changes:
- clicking on folder and heading to the element tab there should be a isPiece toggle.
- isPiece flag exports
- when importing an attachment in BB if isPiece is off we should have the same behaviour as in the game (attachment being on the feet)