### PR TITLE
Fix: Respect Blockbench Visibility and Export toggles

### DIFF
--- a/src/blockymodel.ts
+++ b/src/blockymodel.ts
@@ -283,7 +283,7 @@ export function setupBlockymodelCodec(): Codec {
 				}
 				node.shape.stretch = formatVector(stretch);
 
-				node.shape.visible = true;
+				node.shape.visible = cube.visibility;
 				node.shape.doubleSided = cube.double_sided == true;
 				node.shape.shadingMode = cube.shading_mode;
 				node.shape.unwrapMode = 'custom';
@@ -388,6 +388,9 @@ export function setupBlockymodelCodec(): Codec {
 			}
 
 			function compileNode(element: Group | Cube, name: string = element.name): BlockymodelNode | undefined {
+				// Check the Export toggle immediately
+    			if (!element.export) return undefined;
+
 				// Filter attachment
 				if (!options.attachment) {
 					let collection = Collection.all.find(c => c.contains(element));
@@ -429,7 +432,7 @@ export function setupBlockymodelCodec(): Codec {
 						},
 						textureLayout: {},
 						unwrapMode: "custom",
-						visible: true,
+						visible: element.visibility,
 						doubleSided: false,
 						shadingMode: "flat"
 					},
@@ -442,6 +445,7 @@ export function setupBlockymodelCodec(): Codec {
 					let shape_count = 0;
 					let child_cube_count = 0;
 					for (let child of element.children ?? []) {
+						if (!child.export) continue;
 						let result: BlockymodelNode;
 						if (qualifiesAsMainShape(child) && shape_count == 0) {
 							turnNodeIntoBox(node, child as CubeHytale, element);


### PR DESCRIPTION
Currently, the Hytale exporter ignores the native Blockbench "Visibility" and "Export" toggles. This causes reference meshes to appear in-game and makes it impossible to create invisible rig bones.

<img width="69" height="56" alt="image" src="https://github.com/user-attachments/assets/b64cafcd-4557-4969-990d-caae996dbc97" />

This PR updates `src/blockymodel.ts` to fully respect these settings:

* **Export Toggle:** If unchecked, the node is completely excluded from the JSON.
    * *Fixes "Ghost Blocks":* Added a check to explicitly skip non-exported children during the compile loop. This prevents the plugin from accidentally merging a hidden child cube into its parent folder (which caused hidden blocks to appear in-game).
* **Visibility Toggle:** If unchecked, the node sets `"visible": false` in the Hytale properties.
    * This allows for "Ghost Bones" (invisible parents) to exist in the file to drive animations without rendering in-game.