### PR TITLE
Colorpicking empty pixel changes the tool to eraser

### DIFF
--- a/src/color_picker_eraser.ts
+++ b/src/color_picker_eraser.ts
@@ -1,0 +1,58 @@
+//! Copyright (C) 2025 Hypixel Studios Canada inc.
+//! Licensed under the GNU General Public License, see LICENSE.MD
+
+import { track } from "./cleanup";
+import { FORMAT_IDS } from "./formats";
+
+/**
+ * Hooks into the color picker tool to switch to the eraser when picking an empty pixel.
+ * Only active for Hytale formats and when the setting is enabled.
+ */
+export function setupColorPickerEraser() {
+
+    let setting = new Setting('color_picker_eraser_switch', {
+        name: 'Color Picker Eraser Switch',
+        description: 'When using the color picker on an empty (transparent) pixel, automatically switch to the eraser tool',
+        type: 'toggle',
+        category: 'paint',
+        value: true
+    });
+    track(setting);
+
+    let color_picker = BarItems.color_picker as Tool;
+
+    let original_onTextureEditorClick = color_picker.onTextureEditorClick;
+    color_picker.onTextureEditorClick = function(texture: any, x: number, y: number, event: MouseEvent) {
+        if (setting.value && FORMAT_IDS.includes(Format.id)) {
+            try {
+                let ctx: CanvasRenderingContext2D;
+
+                if (texture?.ctx) {
+                    ctx = texture.ctx;
+                } else if (texture?.canvas) {
+                    ctx = texture.canvas.getContext('2d');
+                }
+
+                if (ctx) {
+                    let pixel = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1).data;
+
+                    if (pixel[3] === 0) {
+                        (BarItems.eraser as Tool)?.select();
+                        Blockbench.showQuickMessage('Switched to Eraser', 1000);
+                        return;
+                    }
+                }
+            } catch (e) {
+                // Fall through to original behavior
+            }
+        }
+
+        return original_onTextureEditorClick?.call(this, texture, x, y, event);
+    };
+
+    track({
+        delete() {
+            color_picker.onTextureEditorClick = original_onTextureEditorClick;
+        }
+    });
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,6 +18,7 @@ import { setupNameOverlap } from "./name_overlap";
 import { setupUVOutline } from "./uv_outline";
 import { setupTempFixes } from './temp_fixes'
 import { setupPreviewScenes } from "./preview_scenes";
+import { setupColorPickerEraser } from "./color_picker_eraser";
 
 BBPlugin.register('hytale_plugin', {
     title: 'Hytale Models',
@@ -55,6 +56,7 @@ BBPlugin.register('hytale_plugin', {
         setupUVOutline();
         setupTempFixes();
         setupPreviewScenes();
+        setupColorPickerEraser();
 
         // Collections panel setting
         let panel_setup_listener: Deletable;


### PR DESCRIPTION
Adding setting to quick switch of tool: when colorpicker is used on an empty pixel it returns the eraser instead of picking the color black