### PR TITLE
Fix keyframe list initialization with safety check

### DIFF
--- a/src/blockyanim.ts
+++ b/src/blockyanim.ts
@@ -137,7 +137,9 @@ function compileAnimationFile(animation: _Animation): IBlockyAnimJSON {
 			let timeline: IKeyframe[];
 			let hytale_channel_key = channels[channel];
 			timeline = timeline = node_data[hytale_channel_key] = [];
-			let keyframe_list = (animator[channel].slice() as _Keyframe[]);
+			let keyframe_list = (animator[channel] && Array.isArray(animator[channel]))
+            ? animator[channel].slice()
+            : [];
 			keyframe_list.sort((a, b) => a.time - b.time);
 			for (let kf of keyframe_list) {
 				let data_point = kf.data_points[0];


### PR DESCRIPTION
Prevent

<img width="1323" height="78" alt="image" src="https://github.com/user-attachments/assets/8d970487-65ca-4f79-9cd2-6952a0806ddd" />

when saving animation when using Hytale plugin models