### PR TITLE
Vertex snap improvements

### DIFF
--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4547,6 +4547,7 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     }
     document.addEventListener("keydown", onKeyDown, true);
     let snapTo = new BarSelect("snap_to", {
+      name: "Vertex Snap To",
       options: {
         vertex: { name: "Vertex", icon: "fiber_manual_record" },
         edge: { name: "Edge", icon: "pen_size_3" },

--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4129,6 +4129,7 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
   }
 
   // src/pivot_snap.ts
+  var CORNER_COUNT = 8;
   var CUBE_EDGES = [
     [0, 1],
     [0, 5],
@@ -4160,36 +4161,38 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     [1, 3, 4, 6]
     // North (z = from)
   ];
-  function midpoint(a, b) {
-    return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
-  }
-  function centroid(points) {
-    let x = 0, y = 0, z = 0;
-    for (let p of points) {
-      x += p[0];
-      y += p[1];
-      z += p[2];
-    }
-    let n = points.length;
-    return [x / n, y / n, z / n];
-  }
   function getSnapTo() {
     return BarItems.snap_to?.value ?? "vertex";
   }
   function buildSnapPoints(corners, mode) {
-    let points = [];
-    if (mode === "vertex") {
-      points.push(...corners);
-    } else if (mode === "edge") {
-      for (let [a, b] of CUBE_EDGES) {
-        points.push(midpoint(corners[a], corners[b]));
-      }
-    } else {
-      for (let face of CUBE_FACES) {
-        points.push(centroid(face.map((i) => corners[i])));
-      }
+    if (mode === "vertex") return corners.slice();
+    if (mode === "edge") {
+      return CUBE_EDGES.map(([ai, bi]) => {
+        let a = corners[ai], b = corners[bi];
+        return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+      });
     }
-    return points;
+    return CUBE_FACES.map((face) => {
+      let x = 0, y = 0, z = 0;
+      for (let i of face) {
+        x += corners[i][0];
+        y += corners[i][1];
+        z += corners[i][2];
+      }
+      return [x / face.length, y / face.length, z / face.length];
+    });
+  }
+  var _accentColor = null;
+  var _sourceElement = null;
+  function getAccentColor() {
+    if (!_accentColor) {
+      let css = getComputedStyle(document.body).getPropertyValue("--color-accent").trim();
+      _accentColor = new THREE.Color(css || "#3e90ff");
+    }
+    return _accentColor;
+  }
+  function invalidateAccentColor() {
+    _accentColor = null;
   }
   function rebuildPointsGeometry(pts, verts) {
     let positions = [];
@@ -4203,45 +4206,53 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     pts.geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positions), 3));
     pts.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
   }
-  var _accentColor = null;
-  function getAccentColor() {
-    if (!_accentColor) {
-      let css = getComputedStyle(document.body).getPropertyValue("--color-accent").trim();
-      _accentColor = new THREE.Color(css || "#3e90ff");
-    }
-    return _accentColor;
-  }
-  function setParentPivotColor(pts) {
-    if (pts._parent_pivot_index == null) return;
-    let colorAttr = pts.geometry.attributes.color;
+  function recolorElementPoints(el, hoveredIndex, isHoveredElement) {
+    let points = el.mesh?.vertex_points;
+    if (!points) return;
+    let colorAttr = points.geometry.attributes.color;
     if (!colorAttr) return;
-    let idx = pts._parent_pivot_index * 3;
-    if (idx + 2 >= colorAttr.array.length) return;
-    let accent = getAccentColor();
-    colorAttr.array[idx] = accent.r;
-    colorAttr.array[idx + 1] = accent.g;
-    colorAttr.array[idx + 2] = accent.b;
+    let arr = colorAttr.array;
+    let sourceIdx = !Vertexsnap.step1 && el === _sourceElement ? Vertexsnap.vertex_index : -1;
+    let count = points.geometry.attributes.position.count;
+    for (let i = 0; i < count; i++) {
+      let color;
+      if (i === hoveredIndex) {
+        color = gizmo_colors.outline;
+      } else if (i === sourceIdx) {
+        color = getAccentColor();
+      } else {
+        color = gizmo_colors.grid;
+      }
+      let offset = i * 3;
+      arr[offset] = color.r;
+      arr[offset + 1] = color.g;
+      arr[offset + 2] = color.b;
+    }
     colorAttr.needsUpdate = true;
+    points.material.depthTest = !isHoveredElement;
   }
+  var _mouse = new THREE.Vector2();
+  var _raycaster = new THREE.Raycaster();
+  var _camDir = new THREE.Vector3();
+  var _plane = new THREE.Plane();
+  var _target = new THREE.Vector3();
   function projectMouseToPlane(event, refPoint) {
     let preview = Preview.selected;
     if (!preview) return null;
     let canvasOffset = $(preview.canvas).offset();
     if (!canvasOffset) return null;
-    let mouse = new THREE.Vector2(
+    _mouse.set(
       (event.clientX - canvasOffset.left) / preview.width * 2 - 1,
       -((event.clientY - canvasOffset.top) / preview.height) * 2 + 1
     );
-    let raycaster = new THREE.Raycaster();
-    raycaster.setFromCamera(mouse, preview.camera);
-    let camDir = new THREE.Vector3();
-    preview.camera.getWorldDirection(camDir);
-    let plane = new THREE.Plane();
-    plane.setFromNormalAndCoplanarPoint(camDir, refPoint);
-    let target = new THREE.Vector3();
-    return raycaster.ray.intersectPlane(plane, target) ? target : null;
+    _raycaster.setFromCamera(_mouse, preview.camera);
+    preview.camera.getWorldDirection(_camDir);
+    _plane.setFromNormalAndCoplanarPoint(_camDir, refPoint);
+    return _raycaster.ray.intersectPlane(_plane, _target) ? _target.clone() : null;
   }
   function setupPivotSnap() {
+    let previewEl;
+    let _prevHoveredEl = null;
     let guideLine = new THREE.Line(
       new THREE.BufferGeometry(),
       new THREE.LineBasicMaterial({ color: getAccentColor(), depthTest: false, transparent: true })
@@ -4260,6 +4271,12 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     );
     sourceMarker.renderOrder = 901;
     sourceMarker.frustumCulled = false;
+    function updateAccentColors() {
+      invalidateAccentColor();
+      let color = getAccentColor();
+      guideLine.material.color.copy(color);
+      sourceMarker.material.color.copy(color);
+    }
     function showSourceMarker(pos) {
       sourceMarker.geometry.setAttribute("position", new THREE.BufferAttribute(
         new Float32Array(pos.toArray()),
@@ -4274,6 +4291,12 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     function removeGuideLine() {
       Project.model_3d.remove(guideLine);
     }
+    function resetSnapVisuals() {
+      removeGuideLine();
+      removeSourceMarker();
+      _parentPivotGroup = null;
+      _sourceElement = null;
+    }
     function drawGuideLine(start, end) {
       guideLine.geometry.setAttribute("position", new THREE.BufferAttribute(
         new Float32Array([...start.toArray(), ...end.toArray()]),
@@ -4282,12 +4305,28 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       Project.model_3d.add(guideLine);
       guideLine.position.copy(scene.position).multiplyScalar(-1);
     }
+    function getPreviewEl() {
+      if (!previewEl) previewEl = $("#preview").get(0);
+      return previewEl;
+    }
     function addHoverListener() {
-      let el = $("#preview").get(0);
+      let el = getPreviewEl();
       if (el) {
         el.removeEventListener("mousemove", Vertexsnap.hoverCanvas);
         el.addEventListener("mousemove", Vertexsnap.hoverCanvas);
       }
+    }
+    function enterStep2(pos) {
+      showSourceMarker(pos);
+      addHoverListener();
+      $("#preview").css("cursor", "alias");
+      Blockbench.setStatusBarText();
+    }
+    function enterStep1() {
+      resetSnapVisuals();
+      Vertexsnap.step1 = true;
+      $("#preview").css("cursor", "copy");
+      Blockbench.setStatusBarText();
     }
     let originalAddVertices = Vertexsnap.addVertices;
     Vertexsnap.addVertices = function(element) {
@@ -4297,13 +4336,11 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       if (!(element instanceof Cube)) return;
       let pts = mesh.vertex_points;
       let verts = pts.vertices;
-      if (verts.length < 9) return;
-      let corners = verts.slice(0, 8);
+      if (verts.length < CORNER_COUNT + 1) return;
+      let corners = verts.slice(0, CORNER_COUNT);
       pts._snap_corners = corners;
-      let mode = getSnapTo();
-      let snapPoints = buildSnapPoints(corners, mode);
-      let origin = [0, 0, 0];
-      let allPoints = [...snapPoints, origin];
+      let snapPoints = buildSnapPoints(corners, getSnapTo());
+      let allPoints = [...snapPoints, [0, 0, 0]];
       pts._parent_pivot_index = null;
       let parentGroup = element.parent;
       if (parentGroup instanceof Group && parentGroup.mesh) {
@@ -4314,14 +4351,27 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
         allPoints.push(localPos.toArray());
       }
       rebuildPointsGeometry(pts, allPoints);
-      setParentPivotColor(pts);
       if (pts._parent_pivot_index != null) {
         pts.renderOrder = 901;
+        pts.material.depthTest = false;
+      }
+      if (!Vertexsnap.step1 && element === _sourceElement) {
+        let idx = Vertexsnap.vertex_index;
+        let colorAttr = pts.geometry.attributes.color;
+        if (idx >= 0 && idx < allPoints.length && colorAttr) {
+          let accent = getAccentColor();
+          let offset = idx * 3;
+          colorAttr.array[offset] = accent.r;
+          colorAttr.array[offset + 1] = accent.g;
+          colorAttr.array[offset + 2] = accent.b;
+          colorAttr.needsUpdate = true;
+        }
       }
     };
     let originalClearVertexGizmos = Vertexsnap.clearVertexGizmos;
     Vertexsnap.clearVertexGizmos = function() {
       removeGuideLine();
+      _prevHoveredEl = null;
       originalClearVertexGizmos.call(this);
       if (!Vertexsnap.step1) {
         addHoverListener();
@@ -4337,12 +4387,11 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
           if (parentGroup instanceof Group) {
             Vertexsnap.step1 = false;
             Vertexsnap.vertex_pos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+            Vertexsnap.vertex_index = data.vertex_index;
+            _sourceElement = data.element;
             _parentPivotGroup = parentGroup;
             Vertexsnap.clearVertexGizmos();
-            showSourceMarker(Vertexsnap.vertex_pos);
-            addHoverListener();
-            $("#preview").css("cursor", "alias");
-            Blockbench.setStatusBarText();
+            enterStep2(Vertexsnap.vertex_pos);
             return;
           }
         }
@@ -4376,22 +4425,17 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
           selection: true
         });
         Undo.finishEdit("Use vertex snap");
-        removeGuideLine();
-        removeSourceMarker();
-        _parentPivotGroup = null;
-        Vertexsnap.step1 = true;
-        $("#preview").css("cursor", "copy");
-        Blockbench.setStatusBarText();
+        enterStep1();
         return;
       }
       let wasStep1 = Vertexsnap.step1;
       originalCanvasClick.call(this, data);
       if (wasStep1 && !Vertexsnap.step1) {
+        _sourceElement = data?.element;
         showSourceMarker(Vertexsnap.vertex_pos);
         addHoverListener();
       } else if (!wasStep1 && Vertexsnap.step1) {
-        removeGuideLine();
-        removeSourceMarker();
+        resetSnapVisuals();
       }
     };
     let originalHoverCanvas = Vertexsnap.hoverCanvas;
@@ -4400,25 +4444,19 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       if (Vertexsnap.hovering) {
         Project.model_3d.remove(Vertexsnap.line);
         removeGuideLine();
-        for (let el of Vertexsnap.elements_with_vertex_gizmos) {
-          let points = el.mesh?.vertex_points;
-          if (!points) continue;
-          let colors = [];
-          let count = points.geometry.attributes.position.count;
-          for (let i = 0; i < count; i++) {
-            let color;
-            if (data && data.element == el && data.type == "vertex" && data.vertex_index == i) {
-              color = gizmo_colors.outline;
-            } else if (points._parent_pivot_index != null && i === points._parent_pivot_index) {
-              color = getAccentColor();
-            } else {
-              color = gizmo_colors.grid;
-            }
-            colors.push(color.r, color.g, color.b);
-          }
-          points.material.depthTest = !(data && data.element == el);
-          points.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+        if (_prevHoveredEl) {
+          recolorElementPoints(_prevHoveredEl, -1, false);
+          _prevHoveredEl = null;
         }
+      }
+      let hoveredEl = data?.element;
+      if (hoveredEl?.mesh?.vertex_points) {
+        if (data.type === "vertex") {
+          recolorElementPoints(hoveredEl, data.vertex_index, true);
+        } else {
+          hoveredEl.mesh.vertex_points.material.depthTest = false;
+        }
+        _prevHoveredEl = hoveredEl;
       }
       if (!Vertexsnap.step1 && Vertexsnap.vertex_pos) {
         let endPos = null;
@@ -4441,6 +4479,19 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       }
       Vertexsnap.hovering = true;
     };
+    function cancelSnap() {
+      if (Vertexsnap.step1) return;
+      Vertexsnap.hovering = false;
+      enterStep1();
+      Vertexsnap.select();
+    }
+    function onKeyDown(event) {
+      if (event.key === "Escape" && !Vertexsnap.step1 && Toolbox.selected?.id === "vertex_snap_tool") {
+        event.stopPropagation();
+        cancelSnap();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown, true);
     let snapTo = new BarSelect("snap_to", {
       options: {
         vertex: { name: "Vertex", icon: "fiber_manual_record" },
@@ -4458,7 +4509,7 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     let toolbar = Toolbars.vertex_snap;
     if (toolbar) {
       let origChildren = toolbar.default_children.slice();
-      toolbar.default_children.splice(1, 0, "snap_to");
+      toolbar.default_children = [...origChildren.slice(0, 1), "snap_to", ...origChildren.slice(1)];
       toolbar.build({ children: toolbar.default_children });
       track({
         delete() {
@@ -4467,14 +4518,17 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
         }
       });
     }
+    Blockbench.on("update_selection", updateAccentColors);
     track({
       delete() {
         Vertexsnap.addVertices = originalAddVertices;
         Vertexsnap.canvasClick = originalCanvasClick;
         Vertexsnap.hoverCanvas = originalHoverCanvas;
         Vertexsnap.clearVertexGizmos = originalClearVertexGizmos;
-        removeGuideLine();
-        removeSourceMarker();
+        document.removeEventListener("keydown", onKeyDown, true);
+        Blockbench.removeListener("update_selection", updateAccentColors);
+        resetSnapVisuals();
+        invalidateAccentColor();
         guideLine.geometry.dispose();
         guideLine.material.dispose();
         sourceMarker.geometry.dispose();

--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4203,6 +4203,26 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     pts.geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positions), 3));
     pts.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
   }
+  var _accentColor = null;
+  function getAccentColor() {
+    if (!_accentColor) {
+      let css = getComputedStyle(document.body).getPropertyValue("--color-accent").trim();
+      _accentColor = new THREE.Color(css || "#3e90ff");
+    }
+    return _accentColor;
+  }
+  function setParentPivotColor(pts) {
+    if (pts._parent_pivot_index == null) return;
+    let colorAttr = pts.geometry.attributes.color;
+    if (!colorAttr) return;
+    let idx = pts._parent_pivot_index * 3;
+    if (idx + 2 >= colorAttr.array.length) return;
+    let accent = getAccentColor();
+    colorAttr.array[idx] = accent.r;
+    colorAttr.array[idx + 1] = accent.g;
+    colorAttr.array[idx + 2] = accent.b;
+    colorAttr.needsUpdate = true;
+  }
   function setupPivotSnap() {
     let originalAddVertices = Vertexsnap.addVertices;
     Vertexsnap.addVertices = function(element) {
@@ -4218,7 +4238,96 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       let mode = getSnapTo();
       let snapPoints = buildSnapPoints(corners, mode);
       let origin = [0, 0, 0];
-      rebuildPointsGeometry(pts, [...snapPoints, origin]);
+      let allPoints = [...snapPoints, origin];
+      pts._parent_pivot_index = null;
+      let parentGroup = element.parent;
+      if (parentGroup instanceof Group && parentGroup.mesh) {
+        let groupWorldPos = new THREE.Vector3();
+        parentGroup.mesh.getWorldPosition(groupWorldPos);
+        let localPos = mesh.worldToLocal(groupWorldPos.clone());
+        pts._parent_pivot_index = allPoints.length;
+        allPoints.push(localPos.toArray());
+      }
+      rebuildPointsGeometry(pts, allPoints);
+      setParentPivotColor(pts);
+      if (pts._parent_pivot_index != null) {
+        pts.renderOrder = 901;
+      }
+    };
+    let originalCanvasClick = Vertexsnap.canvasClick;
+    let _parentPivotGroup = null;
+    Vertexsnap.canvasClick = function(data) {
+      if (data?.type === "vertex" && Vertexsnap.step1) {
+        let pts = data.element?.mesh?.vertex_points;
+        if (pts?._parent_pivot_index != null && data.vertex_index === pts._parent_pivot_index) {
+          let parentGroup = data.element.parent;
+          if (parentGroup instanceof Group) {
+            Vertexsnap.step1 = false;
+            Vertexsnap.vertex_pos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+            _parentPivotGroup = parentGroup;
+            Vertexsnap.clearVertexGizmos();
+            $("#preview").css("cursor", "alias");
+            Blockbench.setStatusBarText();
+            return;
+          }
+        }
+      }
+      if (!Vertexsnap.step1 && _parentPivotGroup) {
+        if (!data) return;
+        if (data.type !== "vertex" && !["locator", "null_object"].includes(data.element?.type)) return;
+        let group = _parentPivotGroup;
+        let allGroups = [group];
+        group.forEachChild((child) => {
+          allGroups.push(child);
+        }, Group);
+        let elements = [];
+        group.forEachChild((child) => {
+          elements.push(child);
+        }, OutlinerElement);
+        Undo.initEdit({ elements, groups: allGroups, outliner: true });
+        let vec = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+        if (Format.bone_rig && group.parent instanceof Group && group.mesh.parent) {
+          group.mesh.parent.worldToLocal(vec);
+        }
+        let vec_array = vec.toArray();
+        if (group.parent instanceof Group) {
+          vec_array.V3_add(group.parent.origin);
+        }
+        group.transferOrigin(vec_array);
+        Canvas.updateAllBones(allGroups);
+        Canvas.updateView({
+          elements,
+          element_aspects: { transform: true, geometry: true },
+          selection: true
+        });
+        Undo.finishEdit("Use vertex snap");
+        _parentPivotGroup = null;
+        Vertexsnap.step1 = true;
+        $("#preview").css("cursor", "copy");
+        Blockbench.setStatusBarText();
+        return;
+      }
+      originalCanvasClick.call(this, data);
+    };
+    let originalHoverCanvas = Vertexsnap.hoverCanvas;
+    Vertexsnap.hoverCanvas = function(event) {
+      originalHoverCanvas.call(this, event);
+      for (let el of Vertexsnap.elements_with_vertex_gizmos) {
+        let pts = el.mesh?.vertex_points;
+        if (!pts || pts._parent_pivot_index == null) continue;
+        let colorAttr = pts.geometry.attributes.color;
+        if (!colorAttr) continue;
+        let idx = pts._parent_pivot_index * 3;
+        if (idx + 2 >= colorAttr.array.length) continue;
+        let { r, g, b } = gizmo_colors.grid;
+        if (colorAttr.array[idx] === r && colorAttr.array[idx + 1] === g && colorAttr.array[idx + 2] === b) {
+          let accent = getAccentColor();
+          colorAttr.array[idx] = accent.r;
+          colorAttr.array[idx + 1] = accent.g;
+          colorAttr.array[idx + 2] = accent.b;
+          colorAttr.needsUpdate = true;
+        }
+      }
     };
     let snapTo = new BarSelect("snap_to", {
       options: {
@@ -4249,6 +4358,8 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     track({
       delete() {
         Vertexsnap.addVertices = originalAddVertices;
+        Vertexsnap.canvasClick = originalCanvasClick;
+        Vertexsnap.hoverCanvas = originalHoverCanvas;
       }
     });
   }

--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4161,26 +4161,84 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     [1, 3, 4, 6]
     // North (z = from)
   ];
+  var COLLAPSE_PAIRS = [
+    [[0, 5], [1, 4], [2, 7], [3, 6]],
+    // X
+    [[0, 2], [1, 3], [4, 6], [5, 7]],
+    // Y
+    [[0, 1], [2, 3], [4, 5], [6, 7]]
+    // Z
+  ];
   function getSnapTo() {
     return BarItems.snap_to?.value ?? "vertex";
   }
-  function buildSnapPoints(corners, mode) {
-    if (mode === "vertex") return corners.slice();
-    if (mode === "edge") {
-      return CUBE_EDGES.map(([ai, bi]) => {
-        let a = corners[ai], b = corners[bi];
-        return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+  function getCornerMergeMap(element) {
+    let hasCollapse = false;
+    let map = /* @__PURE__ */ new Map();
+    for (let i = 0; i < CORNER_COUNT; i++) map.set(i, i);
+    for (let dim = 0; dim < 3; dim++) {
+      if (element.from[dim] !== element.to[dim]) continue;
+      hasCollapse = true;
+      for (let [a, b] of COLLAPSE_PAIRS[dim]) {
+        let ca = map.get(a), cb = map.get(b);
+        let keep = Math.min(ca, cb), drop = Math.max(ca, cb);
+        if (keep === drop) continue;
+        for (let [k, v] of map) {
+          if (v === drop) map.set(k, keep);
+        }
+      }
+    }
+    return hasCollapse ? map : null;
+  }
+  function midpoint(a, b) {
+    return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+  }
+  function buildSnapPoints(corners, mode, mergeMap) {
+    if (!mergeMap) {
+      if (mode === "vertex") return corners.slice();
+      if (mode === "edge") return CUBE_EDGES.map(([a, b]) => midpoint(corners[a], corners[b]));
+      return CUBE_FACES.map((face) => {
+        let x = 0, y = 0, z = 0;
+        for (let i of face) {
+          x += corners[i][0];
+          y += corners[i][1];
+          z += corners[i][2];
+        }
+        return [x / face.length, y / face.length, z / face.length];
       });
     }
-    return CUBE_FACES.map((face) => {
+    let canonicals = [...new Set(mergeMap.values())].sort((a, b) => a - b);
+    if (mode === "vertex") return canonicals.map((i) => corners[i]);
+    if (mode === "edge") {
+      let seen2 = /* @__PURE__ */ new Set();
+      let points2 = [];
+      for (let [ai, bi] of CUBE_EDGES) {
+        let ca = mergeMap.get(ai), cb = mergeMap.get(bi);
+        if (ca === cb) continue;
+        let key = Math.min(ca, cb) + "," + Math.max(ca, cb);
+        if (seen2.has(key)) continue;
+        seen2.add(key);
+        points2.push(midpoint(corners[ca], corners[cb]));
+      }
+      return points2;
+    }
+    let seen = /* @__PURE__ */ new Set();
+    let points = [];
+    for (let face of CUBE_FACES) {
+      let unique = [...new Set(face.map((i) => mergeMap.get(i)))].sort((a, b) => a - b);
+      if (unique.length < 3) continue;
+      let key = unique.join(",");
+      if (seen.has(key)) continue;
+      seen.add(key);
       let x = 0, y = 0, z = 0;
-      for (let i of face) {
+      for (let i of unique) {
         x += corners[i][0];
         y += corners[i][1];
         z += corners[i][2];
       }
-      return [x / face.length, y / face.length, z / face.length];
-    });
+      points.push([x / unique.length, y / unique.length, z / unique.length]);
+    }
+    return points;
   }
   var _accentColor = null;
   var _sourceElement = null;
@@ -4339,7 +4397,8 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       if (verts.length < CORNER_COUNT + 1) return;
       let corners = verts.slice(0, CORNER_COUNT);
       pts._snap_corners = corners;
-      let snapPoints = buildSnapPoints(corners, getSnapTo());
+      let mergeMap = getCornerMergeMap(element);
+      let snapPoints = buildSnapPoints(corners, getSnapTo(), mergeMap);
       let allPoints = [...snapPoints, [0, 0, 0]];
       pts._parent_pivot_index = null;
       let parentGroup = element.parent;

--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4264,7 +4264,7 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     pts.geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positions), 3));
     pts.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
   }
-  function recolorElementPoints(el, hoveredIndex, isHoveredElement) {
+  function recolorElementPoints(el, hoveredIndex) {
     let points = el.mesh?.vertex_points;
     if (!points) return;
     let colorAttr = points.geometry.attributes.color;
@@ -4287,7 +4287,6 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       arr[offset + 2] = color.b;
     }
     colorAttr.needsUpdate = true;
-    points.material.depthTest = !isHoveredElement;
   }
   var _mouse = new THREE.Vector2();
   var _raycaster = new THREE.Raycaster();
@@ -4410,10 +4409,8 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
         allPoints.push(localPos.toArray());
       }
       rebuildPointsGeometry(pts, allPoints);
-      if (pts._parent_pivot_index != null) {
-        pts.renderOrder = 901;
-        pts.material.depthTest = false;
-      }
+      pts.renderOrder = 901;
+      pts.material.depthTest = false;
       if (!Vertexsnap.step1 && element === _sourceElement) {
         let idx = Vertexsnap.vertex_index;
         let colorAttr = pts.geometry.attributes.color;
@@ -4504,16 +4501,14 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
         Project.model_3d.remove(Vertexsnap.line);
         removeGuideLine();
         if (_prevHoveredEl) {
-          recolorElementPoints(_prevHoveredEl, -1, false);
+          recolorElementPoints(_prevHoveredEl, -1);
           _prevHoveredEl = null;
         }
       }
       let hoveredEl = data?.element;
       if (hoveredEl?.mesh?.vertex_points) {
         if (data.type === "vertex") {
-          recolorElementPoints(hoveredEl, data.vertex_index, true);
-        } else {
-          hoveredEl.mesh.vertex_points.material.depthTest = false;
+          recolorElementPoints(hoveredEl, data.vertex_index);
         }
         _prevHoveredEl = hoveredEl;
       }

--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4128,6 +4128,87 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     });
   }
 
+  // src/pivot_snap.ts
+  var CUBE_EDGES = [
+    [0, 1],
+    [0, 5],
+    [1, 4],
+    [4, 5],
+    // Top face
+    [2, 3],
+    [2, 7],
+    [3, 6],
+    [6, 7],
+    // Bottom face
+    [0, 2],
+    [1, 3],
+    [4, 6],
+    [5, 7]
+    // Vertical
+  ];
+  var CUBE_FACES = [
+    [0, 1, 2, 3],
+    // East  (x = to)
+    [4, 5, 6, 7],
+    // West  (x = from)
+    [0, 1, 4, 5],
+    // Up    (y = to)
+    [2, 3, 6, 7],
+    // Down  (y = from)
+    [0, 2, 5, 7],
+    // South (z = to)
+    [1, 3, 4, 6]
+    // North (z = from)
+  ];
+  function midpoint(a, b) {
+    return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+  }
+  function centroid(points) {
+    let x = 0, y = 0, z = 0;
+    for (let p of points) {
+      x += p[0];
+      y += p[1];
+      z += p[2];
+    }
+    let n = points.length;
+    return [x / n, y / n, z / n];
+  }
+  function setupPivotSnap() {
+    let originalAddVertices = Vertexsnap.addVertices;
+    Vertexsnap.addVertices = function(element) {
+      originalAddVertices.call(this, element);
+      let { mesh } = element;
+      if (!mesh?.vertex_points) return;
+      if (!(element instanceof Cube)) return;
+      let pts = mesh.vertex_points;
+      if (pts._snap_augmented) return;
+      pts._snap_augmented = true;
+      let verts = pts.vertices;
+      if (verts.length < 9) return;
+      let corners = verts.slice(0, 8);
+      for (let [a, b2] of CUBE_EDGES) {
+        verts.push(midpoint(corners[a], corners[b2]));
+      }
+      for (let face of CUBE_FACES) {
+        verts.push(centroid(face.map((i) => corners[i])));
+      }
+      let positions = [];
+      let colors = [];
+      let { r, g, b } = gizmo_colors.grid;
+      for (let v of verts) {
+        positions.push(v[0], v[1], v[2]);
+        colors.push(r, g, b);
+      }
+      pts.geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positions), 3));
+      pts.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+    };
+    track({
+      delete() {
+        Vertexsnap.addVertices = originalAddVertices;
+      }
+    });
+  }
+
   // src/plugin.ts
   BBPlugin.register("hytale_plugin", {
     title: "Hytale Models",
@@ -4167,6 +4248,7 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       setupPreviewScenes();
       setupUVCanvasResize();
       setupShortcuts();
+      setupPivotSnap();
       let panel_setup_listener;
       function showCollectionPanel() {
         const local_storage_key = "hytale_plugin:collection_panel_setup";

--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4223,7 +4223,72 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     colorAttr.array[idx + 2] = accent.b;
     colorAttr.needsUpdate = true;
   }
+  function projectMouseToPlane(event, refPoint) {
+    let preview = Preview.selected;
+    if (!preview) return null;
+    let canvasOffset = $(preview.canvas).offset();
+    if (!canvasOffset) return null;
+    let mouse = new THREE.Vector2(
+      (event.clientX - canvasOffset.left) / preview.width * 2 - 1,
+      -((event.clientY - canvasOffset.top) / preview.height) * 2 + 1
+    );
+    let raycaster = new THREE.Raycaster();
+    raycaster.setFromCamera(mouse, preview.camera);
+    let camDir = new THREE.Vector3();
+    preview.camera.getWorldDirection(camDir);
+    let plane = new THREE.Plane();
+    plane.setFromNormalAndCoplanarPoint(camDir, refPoint);
+    let target = new THREE.Vector3();
+    return raycaster.ray.intersectPlane(plane, target) ? target : null;
+  }
   function setupPivotSnap() {
+    let guideLine = new THREE.Line(
+      new THREE.BufferGeometry(),
+      new THREE.LineBasicMaterial({ color: getAccentColor(), depthTest: false, transparent: true })
+    );
+    guideLine.renderOrder = 901;
+    guideLine.frustumCulled = false;
+    let sourceMarker = new THREE.Points(
+      new THREE.BufferGeometry(),
+      new THREE.PointsMaterial({
+        size: 7,
+        sizeAttenuation: false,
+        color: getAccentColor(),
+        depthTest: false,
+        transparent: true
+      })
+    );
+    sourceMarker.renderOrder = 901;
+    sourceMarker.frustumCulled = false;
+    function showSourceMarker(pos) {
+      sourceMarker.geometry.setAttribute("position", new THREE.BufferAttribute(
+        new Float32Array(pos.toArray()),
+        3
+      ));
+      Project.model_3d.add(sourceMarker);
+      sourceMarker.position.copy(scene.position).multiplyScalar(-1);
+    }
+    function removeSourceMarker() {
+      Project.model_3d.remove(sourceMarker);
+    }
+    function removeGuideLine() {
+      Project.model_3d.remove(guideLine);
+    }
+    function drawGuideLine(start, end) {
+      guideLine.geometry.setAttribute("position", new THREE.BufferAttribute(
+        new Float32Array([...start.toArray(), ...end.toArray()]),
+        3
+      ));
+      Project.model_3d.add(guideLine);
+      guideLine.position.copy(scene.position).multiplyScalar(-1);
+    }
+    function addHoverListener() {
+      let el = $("#preview").get(0);
+      if (el) {
+        el.removeEventListener("mousemove", Vertexsnap.hoverCanvas);
+        el.addEventListener("mousemove", Vertexsnap.hoverCanvas);
+      }
+    }
     let originalAddVertices = Vertexsnap.addVertices;
     Vertexsnap.addVertices = function(element) {
       originalAddVertices.call(this, element);
@@ -4254,6 +4319,14 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
         pts.renderOrder = 901;
       }
     };
+    let originalClearVertexGizmos = Vertexsnap.clearVertexGizmos;
+    Vertexsnap.clearVertexGizmos = function() {
+      removeGuideLine();
+      originalClearVertexGizmos.call(this);
+      if (!Vertexsnap.step1) {
+        addHoverListener();
+      }
+    };
     let originalCanvasClick = Vertexsnap.canvasClick;
     let _parentPivotGroup = null;
     Vertexsnap.canvasClick = function(data) {
@@ -4266,6 +4339,8 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
             Vertexsnap.vertex_pos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
             _parentPivotGroup = parentGroup;
             Vertexsnap.clearVertexGizmos();
+            showSourceMarker(Vertexsnap.vertex_pos);
+            addHoverListener();
             $("#preview").css("cursor", "alias");
             Blockbench.setStatusBarText();
             return;
@@ -4301,33 +4376,70 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
           selection: true
         });
         Undo.finishEdit("Use vertex snap");
+        removeGuideLine();
+        removeSourceMarker();
         _parentPivotGroup = null;
         Vertexsnap.step1 = true;
         $("#preview").css("cursor", "copy");
         Blockbench.setStatusBarText();
         return;
       }
+      let wasStep1 = Vertexsnap.step1;
       originalCanvasClick.call(this, data);
+      if (wasStep1 && !Vertexsnap.step1) {
+        showSourceMarker(Vertexsnap.vertex_pos);
+        addHoverListener();
+      } else if (!wasStep1 && Vertexsnap.step1) {
+        removeGuideLine();
+        removeSourceMarker();
+      }
     };
     let originalHoverCanvas = Vertexsnap.hoverCanvas;
     Vertexsnap.hoverCanvas = function(event) {
-      originalHoverCanvas.call(this, event);
-      for (let el of Vertexsnap.elements_with_vertex_gizmos) {
-        let pts = el.mesh?.vertex_points;
-        if (!pts || pts._parent_pivot_index == null) continue;
-        let colorAttr = pts.geometry.attributes.color;
-        if (!colorAttr) continue;
-        let idx = pts._parent_pivot_index * 3;
-        if (idx + 2 >= colorAttr.array.length) continue;
-        let { r, g, b } = gizmo_colors.grid;
-        if (colorAttr.array[idx] === r && colorAttr.array[idx + 1] === g && colorAttr.array[idx + 2] === b) {
-          let accent = getAccentColor();
-          colorAttr.array[idx] = accent.r;
-          colorAttr.array[idx + 1] = accent.g;
-          colorAttr.array[idx + 2] = accent.b;
-          colorAttr.needsUpdate = true;
+      let data = Canvas.raycast(event);
+      if (Vertexsnap.hovering) {
+        Project.model_3d.remove(Vertexsnap.line);
+        removeGuideLine();
+        for (let el of Vertexsnap.elements_with_vertex_gizmos) {
+          let points = el.mesh?.vertex_points;
+          if (!points) continue;
+          let colors = [];
+          let count = points.geometry.attributes.position.count;
+          for (let i = 0; i < count; i++) {
+            let color;
+            if (data && data.element == el && data.type == "vertex" && data.vertex_index == i) {
+              color = gizmo_colors.outline;
+            } else if (points._parent_pivot_index != null && i === points._parent_pivot_index) {
+              color = getAccentColor();
+            } else {
+              color = gizmo_colors.grid;
+            }
+            colors.push(color.r, color.g, color.b);
+          }
+          points.material.depthTest = !(data && data.element == el);
+          points.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
         }
       }
+      if (!Vertexsnap.step1 && Vertexsnap.vertex_pos) {
+        let endPos = null;
+        if (data && data.type === "vertex") {
+          endPos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+          let diff = new THREE.Vector3().copy(Vertexsnap.vertex_pos).sub(endPos);
+          Blockbench.setStatusBarText(tl("status_bar.vertex_distance", [trimFloatNumber(diff.length())]));
+        } else {
+          endPos = projectMouseToPlane(event, Vertexsnap.vertex_pos);
+        }
+        if (endPos) {
+          drawGuideLine(Vertexsnap.vertex_pos, endPos);
+        }
+        Vertexsnap.hovering = true;
+        return;
+      }
+      if (!data || data.type !== "vertex") {
+        Blockbench.setStatusBarText();
+        return;
+      }
+      Vertexsnap.hovering = true;
     };
     let snapTo = new BarSelect("snap_to", {
       options: {
@@ -4360,6 +4472,13 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
         Vertexsnap.addVertices = originalAddVertices;
         Vertexsnap.canvasClick = originalCanvasClick;
         Vertexsnap.hoverCanvas = originalHoverCanvas;
+        Vertexsnap.clearVertexGizmos = originalClearVertexGizmos;
+        removeGuideLine();
+        removeSourceMarker();
+        guideLine.geometry.dispose();
+        guideLine.material.dispose();
+        sourceMarker.geometry.dispose();
+        sourceMarker.material.dispose();
       }
     });
   }

--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -4173,6 +4173,36 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
     let n = points.length;
     return [x / n, y / n, z / n];
   }
+  function getSnapTo() {
+    return BarItems.snap_to?.value ?? "vertex";
+  }
+  function buildSnapPoints(corners, mode) {
+    let points = [];
+    if (mode === "vertex") {
+      points.push(...corners);
+    } else if (mode === "edge") {
+      for (let [a, b] of CUBE_EDGES) {
+        points.push(midpoint(corners[a], corners[b]));
+      }
+    } else {
+      for (let face of CUBE_FACES) {
+        points.push(centroid(face.map((i) => corners[i])));
+      }
+    }
+    return points;
+  }
+  function rebuildPointsGeometry(pts, verts) {
+    let positions = [];
+    let colors = [];
+    let { r, g, b } = gizmo_colors.grid;
+    for (let v of verts) {
+      positions.push(v[0], v[1], v[2]);
+      colors.push(r, g, b);
+    }
+    pts.vertices = verts;
+    pts.geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positions), 3));
+    pts.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+  }
   function setupPivotSnap() {
     let originalAddVertices = Vertexsnap.addVertices;
     Vertexsnap.addVertices = function(element) {
@@ -4181,27 +4211,41 @@ body.hytale-uv-outline-only #uv_frame .selection_rectangle {
       if (!mesh?.vertex_points) return;
       if (!(element instanceof Cube)) return;
       let pts = mesh.vertex_points;
-      if (pts._snap_augmented) return;
-      pts._snap_augmented = true;
       let verts = pts.vertices;
       if (verts.length < 9) return;
       let corners = verts.slice(0, 8);
-      for (let [a, b2] of CUBE_EDGES) {
-        verts.push(midpoint(corners[a], corners[b2]));
-      }
-      for (let face of CUBE_FACES) {
-        verts.push(centroid(face.map((i) => corners[i])));
-      }
-      let positions = [];
-      let colors = [];
-      let { r, g, b } = gizmo_colors.grid;
-      for (let v of verts) {
-        positions.push(v[0], v[1], v[2]);
-        colors.push(r, g, b);
-      }
-      pts.geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positions), 3));
-      pts.geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+      pts._snap_corners = corners;
+      let mode = getSnapTo();
+      let snapPoints = buildSnapPoints(corners, mode);
+      let origin = [0, 0, 0];
+      rebuildPointsGeometry(pts, [...snapPoints, origin]);
     };
+    let snapTo = new BarSelect("snap_to", {
+      options: {
+        vertex: { name: "Vertex", icon: "fiber_manual_record" },
+        edge: { name: "Edge", icon: "pen_size_3" },
+        face: { name: "Face", icon: "far.fa-square" }
+      },
+      icon_mode: true,
+      condition: () => Toolbox.selected?.id === "vertex_snap_tool",
+      onChange() {
+        Vertexsnap.clearVertexGizmos();
+        Vertexsnap.select();
+      }
+    });
+    track(snapTo);
+    let toolbar = Toolbars.vertex_snap;
+    if (toolbar) {
+      let origChildren = toolbar.default_children.slice();
+      toolbar.default_children.splice(1, 0, "snap_to");
+      toolbar.build({ children: toolbar.default_children });
+      track({
+        delete() {
+          toolbar.default_children = origChildren;
+          toolbar.build({ children: origChildren });
+        }
+      });
+    }
     track({
       delete() {
         Vertexsnap.addVertices = originalAddVertices;

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -6,6 +6,8 @@ import { track } from "./cleanup";
 // Vertex order from geometry buffer dedup:
 //   0:(to,to,to) 1:(to,to,from) 2:(to,from,to) 3:(to,from,from)
 //   4:(from,to,from) 5:(from,to,to) 6:(from,from,from) 7:(from,from,to)
+const CORNER_COUNT = 8;
+
 const CUBE_EDGES: [number, number][] = [
 	[0, 1], [0, 5], [1, 4], [4, 5], // Top face
 	[2, 3], [2, 7], [3, 6], [6, 7], // Bottom face
@@ -21,55 +23,32 @@ const CUBE_FACES: number[][] = [
 	[1, 3, 4, 6], // North (z = from)
 ];
 
-function midpoint(a: number[], b: number[]): number[] {
-	return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
-}
-
-function centroid(points: number[][]): number[] {
-	let x = 0, y = 0, z = 0;
-	for (let p of points) { x += p[0]; y += p[1]; z += p[2]; }
-	let n = points.length;
-	return [x / n, y / n, z / n];
-}
-
 type SnapPointMode = 'vertex' | 'edge' | 'face';
 
 function getSnapTo(): SnapPointMode {
-	return (BarItems.snap_to as any)?.value ?? 'vertex';
+	return (BarItems.snap_to as BarSelect)?.value as SnapPointMode ?? 'vertex';
 }
 
 function buildSnapPoints(corners: number[][], mode: SnapPointMode): number[][] {
-	let points: number[][] = [];
+	if (mode === 'vertex') return corners.slice();
 
-	if (mode === 'vertex') {
-		points.push(...corners);
-	} else if (mode === 'edge') {
-		for (let [a, b] of CUBE_EDGES) {
-			points.push(midpoint(corners[a], corners[b]));
-		}
-	} else {
-		for (let face of CUBE_FACES) {
-			points.push(centroid(face.map(i => corners[i])));
-		}
+	if (mode === 'edge') {
+		return CUBE_EDGES.map(([ai, bi]) => {
+			let a = corners[ai], b = corners[bi];
+			return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+		});
 	}
 
-	return points;
-}
-
-function rebuildPointsGeometry(pts: any, verts: number[][]) {
-	let positions: number[] = [];
-	let colors: number[] = [];
-	let { r, g, b } = gizmo_colors.grid;
-	for (let v of verts) {
-		positions.push(v[0], v[1], v[2]);
-		colors.push(r, g, b);
-	}
-	pts.vertices = verts;
-	pts.geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(positions), 3));
-	pts.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+	return CUBE_FACES.map(face => {
+		let x = 0, y = 0, z = 0;
+		for (let i of face) { x += corners[i][0]; y += corners[i][1]; z += corners[i][2]; }
+		return [x / face.length, y / face.length, z / face.length];
+	});
 }
 
 let _accentColor: THREE.Color | null = null;
+let _sourceElement: any = null;
+
 function getAccentColor(): THREE.Color {
 	if (!_accentColor) {
 		let css = getComputedStyle(document.body).getPropertyValue('--color-accent').trim();
@@ -78,39 +57,82 @@ function getAccentColor(): THREE.Color {
 	return _accentColor;
 }
 
-function setParentPivotColor(pts: any) {
-	if (pts._parent_pivot_index == null) return;
-	let colorAttr = pts.geometry.attributes.color;
-	if (!colorAttr) return;
-	let idx = pts._parent_pivot_index * 3;
-	if (idx + 2 >= colorAttr.array.length) return;
-	let accent = getAccentColor();
-	colorAttr.array[idx] = accent.r;
-	colorAttr.array[idx + 1] = accent.g;
-	colorAttr.array[idx + 2] = accent.b;
-	colorAttr.needsUpdate = true;
+function invalidateAccentColor() {
+	_accentColor = null;
 }
+
+function rebuildPointsGeometry(pts: any, verts: number[][]) {
+	let positions: number[] = [];
+	let colors: number[] = [];
+	let { r, g, b } = gizmo_colors.grid;
+
+	for (let v of verts) {
+		positions.push(v[0], v[1], v[2]);
+		colors.push(r, g, b);
+	}
+
+	pts.vertices = verts;
+	pts.geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(positions), 3));
+	pts.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+}
+
+function recolorElementPoints(el: any, hoveredIndex: number, isHoveredElement: boolean) {
+	let points = el.mesh?.vertex_points;
+	if (!points) return;
+
+	let colorAttr = points.geometry.attributes.color;
+	if (!colorAttr) return;
+	let arr = colorAttr.array;
+
+	let sourceIdx = (!Vertexsnap.step1 && el === _sourceElement) ? Vertexsnap.vertex_index : -1;
+	let count = points.geometry.attributes.position.count;
+	for (let i = 0; i < count; i++) {
+		let color;
+		if (i === hoveredIndex) {
+			color = gizmo_colors.outline;
+		} else if (i === sourceIdx) {
+			color = getAccentColor();
+		} else {
+			color = gizmo_colors.grid;
+		}
+		let offset = i * 3;
+		arr[offset] = color.r;
+		arr[offset + 1] = color.g;
+		arr[offset + 2] = color.b;
+	}
+	colorAttr.needsUpdate = true;
+	points.material.depthTest = !isHoveredElement;
+}
+
+// Reusable objects for per-frame raycasting to avoid allocations in mousemove
+const _mouse = new THREE.Vector2();
+const _raycaster = new THREE.Raycaster();
+const _camDir = new THREE.Vector3();
+const _plane = new THREE.Plane();
+const _target = new THREE.Vector3();
 
 function projectMouseToPlane(event: MouseEvent, refPoint: THREE.Vector3): THREE.Vector3 | null {
 	let preview: any = Preview.selected;
 	if (!preview) return null;
 	let canvasOffset = $(preview.canvas).offset();
 	if (!canvasOffset) return null;
-	let mouse = new THREE.Vector2(
+
+	_mouse.set(
 		((event.clientX - canvasOffset.left) / preview.width) * 2 - 1,
 		-((event.clientY - canvasOffset.top) / preview.height) * 2 + 1
 	);
-	let raycaster = new THREE.Raycaster();
-	raycaster.setFromCamera(mouse, preview.camera);
-	let camDir = new THREE.Vector3();
-	preview.camera.getWorldDirection(camDir);
-	let plane = new THREE.Plane();
-	plane.setFromNormalAndCoplanarPoint(camDir, refPoint);
-	let target = new THREE.Vector3();
-	return raycaster.ray.intersectPlane(plane, target) ? target : null;
+	_raycaster.setFromCamera(_mouse, preview.camera);
+	preview.camera.getWorldDirection(_camDir);
+	_plane.setFromNormalAndCoplanarPoint(_camDir, refPoint);
+
+	return _raycaster.ray.intersectPlane(_plane, _target) ? _target.clone() : null;
 }
 
+// Overrides are intentionally global (not gated to Hytale formats) — edge/face
+// snapping and guide lines enhance the vertex snap tool for all format types.
 export function setupPivotSnap() {
+	let previewEl: HTMLElement | undefined;
+	let _prevHoveredEl: any = null;
 	let guideLine = new THREE.Line(
 		new THREE.BufferGeometry(),
 		new THREE.LineBasicMaterial({ color: getAccentColor(), depthTest: false, transparent: true })
@@ -131,6 +153,13 @@ export function setupPivotSnap() {
 	sourceMarker.renderOrder = 901;
 	sourceMarker.frustumCulled = false;
 
+	function updateAccentColors() {
+		invalidateAccentColor();
+		let color = getAccentColor();
+		(guideLine.material as THREE.LineBasicMaterial).color.copy(color);
+		(sourceMarker.material as THREE.PointsMaterial).color.copy(color);
+	}
+
 	function showSourceMarker(pos: THREE.Vector3) {
 		sourceMarker.geometry.setAttribute('position', new THREE.BufferAttribute(
 			new Float32Array(pos.toArray()), 3
@@ -147,6 +176,13 @@ export function setupPivotSnap() {
 		Project.model_3d.remove(guideLine);
 	}
 
+	function resetSnapVisuals() {
+		removeGuideLine();
+		removeSourceMarker();
+		_parentPivotGroup = null;
+		_sourceElement = null;
+	}
+
 	function drawGuideLine(start: THREE.Vector3, end: THREE.Vector3) {
 		guideLine.geometry.setAttribute('position', new THREE.BufferAttribute(
 			new Float32Array([...start.toArray(), ...end.toArray()]), 3
@@ -155,12 +191,31 @@ export function setupPivotSnap() {
 		guideLine.position.copy(scene.position).multiplyScalar(-1);
 	}
 
+	function getPreviewEl(): HTMLElement | undefined {
+		if (!previewEl) previewEl = $('#preview').get(0) as HTMLElement | undefined;
+		return previewEl;
+	}
+
 	function addHoverListener() {
-		let el = $('#preview').get(0);
+		let el = getPreviewEl();
 		if (el) {
 			el.removeEventListener('mousemove', Vertexsnap.hoverCanvas);
 			el.addEventListener('mousemove', Vertexsnap.hoverCanvas);
 		}
+	}
+
+	function enterStep2(pos: THREE.Vector3) {
+		showSourceMarker(pos);
+		addHoverListener();
+		$('#preview').css('cursor', 'alias');
+		Blockbench.setStatusBarText();
+	}
+
+	function enterStep1() {
+		resetSnapVisuals();
+		Vertexsnap.step1 = true;
+		$('#preview').css('cursor', 'copy');
+		Blockbench.setStatusBarText();
 	}
 
 	// --- Override addVertices ---
@@ -175,15 +230,13 @@ export function setupPivotSnap() {
 
 		let pts = mesh.vertex_points;
 		let verts: number[][] = pts.vertices;
-		if (verts.length < 9) return;
+		if (verts.length < CORNER_COUNT + 1) return;
 
-		let corners = verts.slice(0, 8);
+		let corners = verts.slice(0, CORNER_COUNT);
 		pts._snap_corners = corners;
 
-		let mode = getSnapTo();
-		let snapPoints = buildSnapPoints(corners, mode);
-		let origin = [0, 0, 0];
-		let allPoints = [...snapPoints, origin];
+		let snapPoints = buildSnapPoints(corners, getSnapTo());
+		let allPoints = [...snapPoints, [0, 0, 0]];
 
 		pts._parent_pivot_index = null;
 		let parentGroup = element.parent;
@@ -196,16 +249,31 @@ export function setupPivotSnap() {
 		}
 
 		rebuildPointsGeometry(pts, allPoints);
-		setParentPivotColor(pts);
 		if (pts._parent_pivot_index != null) {
 			pts.renderOrder = 901;
+			pts.material.depthTest = false;
+		}
+
+		if (!Vertexsnap.step1 && element === _sourceElement) {
+			let idx = Vertexsnap.vertex_index;
+			let colorAttr = pts.geometry.attributes.color;
+			if (idx >= 0 && idx < allPoints.length && colorAttr) {
+				let accent = getAccentColor();
+				let offset = idx * 3;
+				colorAttr.array[offset] = accent.r;
+				colorAttr.array[offset + 1] = accent.g;
+				colorAttr.array[offset + 2] = accent.b;
+				colorAttr.needsUpdate = true;
+			}
 		}
 	};
 
 	// --- Override clearVertexGizmos ---
 	let originalClearVertexGizmos = Vertexsnap.clearVertexGizmos;
+
 	Vertexsnap.clearVertexGizmos = function () {
 		removeGuideLine();
+		_prevHoveredEl = null;
 		originalClearVertexGizmos.call(this);
 		// Keep hover listener alive during step 2 so guide line persists across selection changes
 		if (!Vertexsnap.step1) {
@@ -226,12 +294,11 @@ export function setupPivotSnap() {
 				if (parentGroup instanceof Group) {
 					Vertexsnap.step1 = false;
 					Vertexsnap.vertex_pos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+					Vertexsnap.vertex_index = data.vertex_index;
+					_sourceElement = data.element;
 					_parentPivotGroup = parentGroup;
 					Vertexsnap.clearVertexGizmos();
-					showSourceMarker(Vertexsnap.vertex_pos);
-					addHoverListener();
-					$('#preview').css('cursor', 'alias');
-					Blockbench.setStatusBarText();
+					enterStep2(Vertexsnap.vertex_pos);
 					return;
 				}
 			}
@@ -268,13 +335,7 @@ export function setupPivotSnap() {
 			});
 
 			Undo.finishEdit('Use vertex snap');
-
-			removeGuideLine();
-			removeSourceMarker();
-			_parentPivotGroup = null;
-			Vertexsnap.step1 = true;
-			$('#preview').css('cursor', 'copy');
-			Blockbench.setStatusBarText();
+			enterStep1();
 			return;
 		}
 
@@ -282,45 +343,38 @@ export function setupPivotSnap() {
 		originalCanvasClick.call(this, data);
 
 		if (wasStep1 && !Vertexsnap.step1) {
-			// Native step 1 completed: show source marker and re-add hover listener
+			_sourceElement = data?.element;
 			showSourceMarker(Vertexsnap.vertex_pos);
 			addHoverListener();
 		} else if (!wasStep1 && Vertexsnap.step1) {
-			// Native step 2 completed
-			removeGuideLine();
-			removeSourceMarker();
+			resetSnapVisuals();
 		}
 	};
 
 	// --- Override hoverCanvas ---
 	let originalHoverCanvas = Vertexsnap.hoverCanvas;
+
 	Vertexsnap.hoverCanvas = function (event: any) {
 		let data = Canvas.raycast(event);
 
-		// Reset vertex colors and remove lines from previous frame
 		if (Vertexsnap.hovering) {
 			Project.model_3d.remove(Vertexsnap.line);
 			removeGuideLine();
 
-			for (let el of Vertexsnap.elements_with_vertex_gizmos) {
-				let points = (el as any).mesh?.vertex_points;
-				if (!points) continue;
-				let colors: number[] = [];
-				let count = points.geometry.attributes.position.count;
-				for (let i = 0; i < count; i++) {
-					let color;
-					if (data && data.element == el && data.type == 'vertex' && data.vertex_index == i) {
-						color = gizmo_colors.outline;
-					} else if (points._parent_pivot_index != null && i === points._parent_pivot_index) {
-						color = getAccentColor();
-					} else {
-						color = gizmo_colors.grid;
-					}
-					colors.push(color.r, color.g, color.b);
-				}
-				points.material.depthTest = !(data && data.element == el);
-				points.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+			if (_prevHoveredEl) {
+				recolorElementPoints(_prevHoveredEl, -1, false);
+				_prevHoveredEl = null;
 			}
+		}
+
+		let hoveredEl = data?.element;
+		if (hoveredEl?.mesh?.vertex_points) {
+			if (data.type === 'vertex') {
+				recolorElementPoints(hoveredEl, data.vertex_index, true);
+			} else {
+				hoveredEl.mesh.vertex_points.material.depthTest = false;
+			}
+			_prevHoveredEl = hoveredEl;
 		}
 
 		// Guide line from source to cursor/target (step 2)
@@ -350,6 +404,23 @@ export function setupPivotSnap() {
 		Vertexsnap.hovering = true;
 	};
 
+	// --- Escape to cancel step 2 ---
+	function cancelSnap() {
+		if (Vertexsnap.step1) return;
+		Vertexsnap.hovering = false;
+		enterStep1();
+		Vertexsnap.select();
+	}
+
+	function onKeyDown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && !Vertexsnap.step1 && Toolbox.selected?.id === 'vertex_snap_tool') {
+			event.stopPropagation();
+			cancelSnap();
+		}
+	}
+
+	document.addEventListener('keydown', onKeyDown, true);
+
 	// --- Snap mode selector ---
 	let snapTo = new BarSelect('snap_to', {
 		options: {
@@ -369,7 +440,7 @@ export function setupPivotSnap() {
 	let toolbar = Toolbars.vertex_snap;
 	if (toolbar) {
 		let origChildren = toolbar.default_children.slice();
-		toolbar.default_children.splice(1, 0, 'snap_to');
+		toolbar.default_children = [...origChildren.slice(0, 1), 'snap_to', ...origChildren.slice(1)];
 		toolbar.build({ children: toolbar.default_children });
 		track({
 			delete() {
@@ -379,14 +450,19 @@ export function setupPivotSnap() {
 		});
 	}
 
+	// Refresh accent-colored materials when selection changes (proxy for theme changes)
+	Blockbench.on('update_selection', updateAccentColors);
+
 	track({
 		delete() {
 			Vertexsnap.addVertices = originalAddVertices;
 			Vertexsnap.canvasClick = originalCanvasClick;
 			Vertexsnap.hoverCanvas = originalHoverCanvas;
 			Vertexsnap.clearVertexGizmos = originalClearVertexGizmos;
-			removeGuideLine();
-			removeSourceMarker();
+			document.removeEventListener('keydown', onKeyDown, true);
+			Blockbench.removeListener('update_selection', updateAccentColors);
+			resetSnapVisuals();
+			invalidateAccentColor();
 			guideLine.geometry.dispose();
 			(guideLine.material as THREE.LineBasicMaterial).dispose();
 			sourceMarker.geometry.dispose();

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -477,6 +477,7 @@ export function setupPivotSnap() {
 
 	// --- Snap mode selector ---
 	let snapTo = new BarSelect('snap_to', {
+		name: 'Vertex Snap To',
 		options: {
 			vertex: { name: 'Vertex', icon: 'fiber_manual_record' },
 			edge: { name: 'Edge', icon: 'pen_size_3' },

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -3,7 +3,6 @@
 
 import { track } from "./cleanup";
 
-// Edge pairs: indices into the 8 cube vertices produced by addVertices.
 // Vertex order from geometry buffer dedup:
 //   0:(to,to,to) 1:(to,to,from) 2:(to,from,to) 3:(to,from,from)
 //   4:(from,to,from) 5:(from,to,to) 6:(from,from,from) 7:(from,from,to)
@@ -33,6 +32,43 @@ function centroid(points: number[][]): number[] {
 	return [x / n, y / n, z / n];
 }
 
+type SnapPointMode = 'vertex' | 'edge' | 'face';
+
+function getSnapTo(): SnapPointMode {
+	return (BarItems.snap_to as any)?.value ?? 'vertex';
+}
+
+function buildSnapPoints(corners: number[][], mode: SnapPointMode): number[][] {
+	let points: number[][] = [];
+
+	if (mode === 'vertex') {
+		points.push(...corners);
+	} else if (mode === 'edge') {
+		for (let [a, b] of CUBE_EDGES) {
+			points.push(midpoint(corners[a], corners[b]));
+		}
+	} else {
+		for (let face of CUBE_FACES) {
+			points.push(centroid(face.map(i => corners[i])));
+		}
+	}
+
+	return points;
+}
+
+function rebuildPointsGeometry(pts: any, verts: number[][]) {
+	let positions: number[] = [];
+	let colors: number[] = [];
+	let { r, g, b } = gizmo_colors.grid;
+	for (let v of verts) {
+		positions.push(v[0], v[1], v[2]);
+		colors.push(r, g, b);
+	}
+	pts.vertices = verts;
+	pts.geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(positions), 3));
+	pts.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+}
+
 export function setupPivotSnap() {
 	let originalAddVertices = Vertexsnap.addVertices;
 
@@ -44,31 +80,46 @@ export function setupPivotSnap() {
 		if (!(element instanceof Cube)) return;
 
 		let pts = mesh.vertex_points;
-		if (pts._snap_augmented) return;
-		pts._snap_augmented = true;
-
 		let verts: number[][] = pts.vertices;
 		if (verts.length < 9) return;
 
 		let corners = verts.slice(0, 8);
+		pts._snap_corners = corners;
 
-		for (let [a, b] of CUBE_EDGES) {
-			verts.push(midpoint(corners[a], corners[b]));
-		}
-		for (let face of CUBE_FACES) {
-			verts.push(centroid(face.map(i => corners[i])));
-		}
-
-		let positions: number[] = [];
-		let colors: number[] = [];
-		let { r, g, b } = gizmo_colors.grid;
-		for (let v of verts) {
-			positions.push(v[0], v[1], v[2]);
-			colors.push(r, g, b);
-		}
-		pts.geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(positions), 3));
-		pts.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+		let mode = getSnapTo();
+		let snapPoints = buildSnapPoints(corners, mode);
+		// Origin is always kept as the last vertex
+		let origin = [0, 0, 0];
+		rebuildPointsGeometry(pts, [...snapPoints, origin]);
 	};
+
+	let snapTo = new BarSelect('snap_to', {
+		options: {
+			vertex: { name: 'Vertex', icon: 'fiber_manual_record' },
+			edge: { name: 'Edge', icon: 'pen_size_3' },
+			face: { name: 'Face', icon: 'far.fa-square' },
+		},
+		icon_mode: true,
+		condition: () => Toolbox.selected?.id === 'vertex_snap_tool',
+		onChange() {
+			Vertexsnap.clearVertexGizmos();
+			Vertexsnap.select();
+		}
+	});
+	track(snapTo);
+
+	let toolbar = Toolbars.vertex_snap;
+	if (toolbar) {
+		let origChildren = toolbar.default_children.slice();
+		toolbar.default_children.splice(1, 0, 'snap_to');
+		toolbar.build({ children: toolbar.default_children });
+		track({
+			delete() {
+				toolbar.default_children = origChildren;
+				toolbar.build({ children: origChildren });
+			}
+		});
+	}
 
 	track({
 		delete() {

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -69,6 +69,28 @@ function rebuildPointsGeometry(pts: any, verts: number[][]) {
 	pts.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
 }
 
+let _accentColor: THREE.Color | null = null;
+function getAccentColor(): THREE.Color {
+	if (!_accentColor) {
+		let css = getComputedStyle(document.body).getPropertyValue('--color-accent').trim();
+		_accentColor = new THREE.Color(css || '#3e90ff');
+	}
+	return _accentColor;
+}
+
+function setParentPivotColor(pts: any) {
+	if (pts._parent_pivot_index == null) return;
+	let colorAttr = pts.geometry.attributes.color;
+	if (!colorAttr) return;
+	let idx = pts._parent_pivot_index * 3;
+	if (idx + 2 >= colorAttr.array.length) return;
+	let accent = getAccentColor();
+	colorAttr.array[idx] = accent.r;
+	colorAttr.array[idx + 1] = accent.g;
+	colorAttr.array[idx + 2] = accent.b;
+	colorAttr.needsUpdate = true;
+}
+
 export function setupPivotSnap() {
 	let originalAddVertices = Vertexsnap.addVertices;
 
@@ -88,9 +110,108 @@ export function setupPivotSnap() {
 
 		let mode = getSnapTo();
 		let snapPoints = buildSnapPoints(corners, mode);
-		// Origin is always kept as the last vertex
 		let origin = [0, 0, 0];
-		rebuildPointsGeometry(pts, [...snapPoints, origin]);
+		let allPoints = [...snapPoints, origin];
+
+		pts._parent_pivot_index = null;
+		let parentGroup = element.parent;
+		if (parentGroup instanceof Group && parentGroup.mesh) {
+			let groupWorldPos = new THREE.Vector3();
+			parentGroup.mesh.getWorldPosition(groupWorldPos);
+			let localPos = mesh.worldToLocal(groupWorldPos.clone());
+			pts._parent_pivot_index = allPoints.length;
+			allPoints.push(localPos.toArray());
+		}
+
+		rebuildPointsGeometry(pts, allPoints);
+		setParentPivotColor(pts);
+		if (pts._parent_pivot_index != null) {
+			pts.renderOrder = 901;
+		}
+	};
+
+	let originalCanvasClick = Vertexsnap.canvasClick;
+	let _parentPivotGroup: any = null;
+
+	Vertexsnap.canvasClick = function (data: any) {
+		// Step 1: pick parent group pivot as snap source
+		if (data?.type === 'vertex' && Vertexsnap.step1) {
+			let pts = data.element?.mesh?.vertex_points;
+			if (pts?._parent_pivot_index != null && data.vertex_index === pts._parent_pivot_index) {
+				let parentGroup = data.element.parent;
+				if (parentGroup instanceof Group) {
+					Vertexsnap.step1 = false;
+					Vertexsnap.vertex_pos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+					_parentPivotGroup = parentGroup;
+					Vertexsnap.clearVertexGizmos();
+					$('#preview').css('cursor', 'alias');
+					Blockbench.setStatusBarText();
+					return;
+				}
+			}
+		}
+
+		// Step 2: snap parent group pivot to target
+		if (!Vertexsnap.step1 && _parentPivotGroup) {
+			if (!data) return;
+			if (data.type !== 'vertex' && !['locator', 'null_object'].includes(data.element?.type)) return;
+
+			let group = _parentPivotGroup;
+			let allGroups: any[] = [group];
+			group.forEachChild((child: any) => { allGroups.push(child); }, Group);
+			let elements: any[] = [];
+			group.forEachChild((child: any) => { elements.push(child); }, OutlinerElement);
+
+			Undo.initEdit({ elements, groups: allGroups, outliner: true });
+
+			let vec = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+			if (Format.bone_rig && group.parent instanceof Group && group.mesh.parent) {
+				group.mesh.parent.worldToLocal(vec);
+			}
+			let vec_array: any = vec.toArray();
+			if (group.parent instanceof Group) {
+				vec_array.V3_add(group.parent.origin);
+			}
+
+			group.transferOrigin(vec_array);
+			Canvas.updateAllBones(allGroups);
+			Canvas.updateView({
+				elements,
+				element_aspects: { transform: true, geometry: true },
+				selection: true,
+			});
+
+			Undo.finishEdit('Use vertex snap');
+
+			_parentPivotGroup = null;
+			Vertexsnap.step1 = true;
+			$('#preview').css('cursor', 'copy');
+			Blockbench.setStatusBarText();
+			return;
+		}
+
+		originalCanvasClick.call(this, data);
+	};
+
+	let originalHoverCanvas = Vertexsnap.hoverCanvas;
+	Vertexsnap.hoverCanvas = function (event: any) {
+		originalHoverCanvas.call(this, event);
+		for (let el of Vertexsnap.elements_with_vertex_gizmos) {
+			let pts = (el as any).mesh?.vertex_points;
+			if (!pts || pts._parent_pivot_index == null) continue;
+			let colorAttr = pts.geometry.attributes.color;
+			if (!colorAttr) continue;
+			let idx = pts._parent_pivot_index * 3;
+			if (idx + 2 >= colorAttr.array.length) continue;
+			let { r, g, b } = gizmo_colors.grid;
+			if (colorAttr.array[idx] === r && colorAttr.array[idx + 1] === g && colorAttr.array[idx + 2] === b) {
+				let accent = getAccentColor();
+				colorAttr.array[idx] = accent.r;
+				colorAttr.array[idx + 1] = accent.g;
+				colorAttr.array[idx + 2] = accent.b;
+				colorAttr.needsUpdate = true;
+			}
+		}
 	};
 
 	let snapTo = new BarSelect('snap_to', {
@@ -124,6 +245,8 @@ export function setupPivotSnap() {
 	track({
 		delete() {
 			Vertexsnap.addVertices = originalAddVertices;
+			Vertexsnap.canvasClick = originalCanvasClick;
+			Vertexsnap.hoverCanvas = originalHoverCanvas;
 		}
 	});
 }

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -1,0 +1,78 @@
+//! Copyright (C) 2025 Hypixel Studios Canada inc.
+//! Licensed under the GNU General Public License, see LICENSE.MD
+
+import { track } from "./cleanup";
+
+// Edge pairs: indices into the 8 cube vertices produced by addVertices.
+// Vertex order from geometry buffer dedup:
+//   0:(to,to,to) 1:(to,to,from) 2:(to,from,to) 3:(to,from,from)
+//   4:(from,to,from) 5:(from,to,to) 6:(from,from,from) 7:(from,from,to)
+const CUBE_EDGES: [number, number][] = [
+	[0, 1], [0, 5], [1, 4], [4, 5], // Top face
+	[2, 3], [2, 7], [3, 6], [6, 7], // Bottom face
+	[0, 2], [1, 3], [4, 6], [5, 7], // Vertical
+];
+
+const CUBE_FACES: number[][] = [
+	[0, 1, 2, 3], // East  (x = to)
+	[4, 5, 6, 7], // West  (x = from)
+	[0, 1, 4, 5], // Up    (y = to)
+	[2, 3, 6, 7], // Down  (y = from)
+	[0, 2, 5, 7], // South (z = to)
+	[1, 3, 4, 6], // North (z = from)
+];
+
+function midpoint(a: number[], b: number[]): number[] {
+	return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+}
+
+function centroid(points: number[][]): number[] {
+	let x = 0, y = 0, z = 0;
+	for (let p of points) { x += p[0]; y += p[1]; z += p[2]; }
+	let n = points.length;
+	return [x / n, y / n, z / n];
+}
+
+export function setupPivotSnap() {
+	let originalAddVertices = Vertexsnap.addVertices;
+
+	Vertexsnap.addVertices = function (element: any) {
+		originalAddVertices.call(this, element);
+
+		let { mesh } = element;
+		if (!mesh?.vertex_points) return;
+		if (!(element instanceof Cube)) return;
+
+		let pts = mesh.vertex_points;
+		if (pts._snap_augmented) return;
+		pts._snap_augmented = true;
+
+		let verts: number[][] = pts.vertices;
+		if (verts.length < 9) return;
+
+		let corners = verts.slice(0, 8);
+
+		for (let [a, b] of CUBE_EDGES) {
+			verts.push(midpoint(corners[a], corners[b]));
+		}
+		for (let face of CUBE_FACES) {
+			verts.push(centroid(face.map(i => corners[i])));
+		}
+
+		let positions: number[] = [];
+		let colors: number[] = [];
+		let { r, g, b } = gizmo_colors.grid;
+		for (let v of verts) {
+			positions.push(v[0], v[1], v[2]);
+			colors.push(r, g, b);
+		}
+		pts.geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(positions), 3));
+		pts.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+	};
+
+	track({
+		delete() {
+			Vertexsnap.addVertices = originalAddVertices;
+		}
+	});
+}

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -23,27 +23,85 @@ const CUBE_FACES: number[][] = [
 	[1, 3, 4, 6], // North (z = from)
 ];
 
+// Corner pairs that collapse when a dimension is flat (from[i] === to[i])
+const COLLAPSE_PAIRS: [number, number][][] = [
+	[[0, 5], [1, 4], [2, 7], [3, 6]], // X
+	[[0, 2], [1, 3], [4, 6], [5, 7]], // Y
+	[[0, 1], [2, 3], [4, 5], [6, 7]], // Z
+];
+
 type SnapPointMode = 'vertex' | 'edge' | 'face';
 
 function getSnapTo(): SnapPointMode {
 	return (BarItems.snap_to as BarSelect)?.value as SnapPointMode ?? 'vertex';
 }
 
-function buildSnapPoints(corners: number[][], mode: SnapPointMode): number[][] {
-	if (mode === 'vertex') return corners.slice();
+function getCornerMergeMap(element: any): Map<number, number> | null {
+	let hasCollapse = false;
+	let map = new Map<number, number>();
+	for (let i = 0; i < CORNER_COUNT; i++) map.set(i, i);
 
-	if (mode === 'edge') {
-		return CUBE_EDGES.map(([ai, bi]) => {
-			let a = corners[ai], b = corners[bi];
-			return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+	for (let dim = 0; dim < 3; dim++) {
+		if (element.from[dim] !== element.to[dim]) continue;
+		hasCollapse = true;
+		for (let [a, b] of COLLAPSE_PAIRS[dim]) {
+			let ca = map.get(a)!, cb = map.get(b)!;
+			let keep = Math.min(ca, cb), drop = Math.max(ca, cb);
+			if (keep === drop) continue;
+			for (let [k, v] of map) {
+				if (v === drop) map.set(k, keep);
+			}
+		}
+	}
+	return hasCollapse ? map : null;
+}
+
+function midpoint(a: number[], b: number[]): number[] {
+	return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+}
+
+function buildSnapPoints(corners: number[][], mode: SnapPointMode, mergeMap?: Map<number, number> | null): number[][] {
+	if (!mergeMap) {
+		if (mode === 'vertex') return corners.slice();
+		if (mode === 'edge') return CUBE_EDGES.map(([a, b]) => midpoint(corners[a], corners[b]));
+		return CUBE_FACES.map(face => {
+			let x = 0, y = 0, z = 0;
+			for (let i of face) { x += corners[i][0]; y += corners[i][1]; z += corners[i][2]; }
+			return [x / face.length, y / face.length, z / face.length];
 		});
 	}
 
-	return CUBE_FACES.map(face => {
+	let canonicals = [...new Set(mergeMap.values())].sort((a, b) => a - b);
+
+	if (mode === 'vertex') return canonicals.map(i => corners[i]);
+
+	if (mode === 'edge') {
+		let seen = new Set<string>();
+		let points: number[][] = [];
+		for (let [ai, bi] of CUBE_EDGES) {
+			let ca = mergeMap.get(ai)!, cb = mergeMap.get(bi)!;
+			if (ca === cb) continue;
+			let key = Math.min(ca, cb) + ',' + Math.max(ca, cb);
+			if (seen.has(key)) continue;
+			seen.add(key);
+			points.push(midpoint(corners[ca], corners[cb]));
+		}
+		return points;
+	}
+
+	let seen = new Set<string>();
+	let points: number[][] = [];
+	for (let face of CUBE_FACES) {
+		let unique = [...new Set(face.map(i => mergeMap.get(i)!))].sort((a, b) => a - b);
+		if (unique.length < 3) continue;
+		let key = unique.join(',');
+		if (seen.has(key)) continue;
+		seen.add(key);
 		let x = 0, y = 0, z = 0;
-		for (let i of face) { x += corners[i][0]; y += corners[i][1]; z += corners[i][2]; }
-		return [x / face.length, y / face.length, z / face.length];
-	});
+		for (let i of unique) { x += corners[i][0]; y += corners[i][1]; z += corners[i][2]; }
+		points.push([x / unique.length, y / unique.length, z / unique.length]);
+	}
+	return points;
 }
 
 let _accentColor: THREE.Color | null = null;
@@ -235,7 +293,8 @@ export function setupPivotSnap() {
 		let corners = verts.slice(0, CORNER_COUNT);
 		pts._snap_corners = corners;
 
-		let snapPoints = buildSnapPoints(corners, getSnapTo());
+		let mergeMap = getCornerMergeMap(element);
+		let snapPoints = buildSnapPoints(corners, getSnapTo(), mergeMap);
 		let allPoints = [...snapPoints, [0, 0, 0]];
 
 		pts._parent_pivot_index = null;

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -134,7 +134,7 @@ function rebuildPointsGeometry(pts: any, verts: number[][]) {
 	pts.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
 }
 
-function recolorElementPoints(el: any, hoveredIndex: number, isHoveredElement: boolean) {
+function recolorElementPoints(el: any, hoveredIndex: number) {
 	let points = el.mesh?.vertex_points;
 	if (!points) return;
 
@@ -159,7 +159,6 @@ function recolorElementPoints(el: any, hoveredIndex: number, isHoveredElement: b
 		arr[offset + 2] = color.b;
 	}
 	colorAttr.needsUpdate = true;
-	points.material.depthTest = !isHoveredElement;
 }
 
 // Reusable objects for per-frame raycasting to avoid allocations in mousemove
@@ -308,10 +307,8 @@ export function setupPivotSnap() {
 		}
 
 		rebuildPointsGeometry(pts, allPoints);
-		if (pts._parent_pivot_index != null) {
-			pts.renderOrder = 901;
-			pts.material.depthTest = false;
-		}
+		pts.renderOrder = 901;
+		pts.material.depthTest = false;
 
 		if (!Vertexsnap.step1 && element === _sourceElement) {
 			let idx = Vertexsnap.vertex_index;
@@ -421,7 +418,7 @@ export function setupPivotSnap() {
 			removeGuideLine();
 
 			if (_prevHoveredEl) {
-				recolorElementPoints(_prevHoveredEl, -1, false);
+				recolorElementPoints(_prevHoveredEl, -1);
 				_prevHoveredEl = null;
 			}
 		}
@@ -429,9 +426,7 @@ export function setupPivotSnap() {
 		let hoveredEl = data?.element;
 		if (hoveredEl?.mesh?.vertex_points) {
 			if (data.type === 'vertex') {
-				recolorElementPoints(hoveredEl, data.vertex_index, true);
-			} else {
-				hoveredEl.mesh.vertex_points.material.depthTest = false;
+				recolorElementPoints(hoveredEl, data.vertex_index);
 			}
 			_prevHoveredEl = hoveredEl;
 		}

--- a/src/pivot_snap.ts
+++ b/src/pivot_snap.ts
@@ -91,7 +91,79 @@ function setParentPivotColor(pts: any) {
 	colorAttr.needsUpdate = true;
 }
 
+function projectMouseToPlane(event: MouseEvent, refPoint: THREE.Vector3): THREE.Vector3 | null {
+	let preview: any = Preview.selected;
+	if (!preview) return null;
+	let canvasOffset = $(preview.canvas).offset();
+	if (!canvasOffset) return null;
+	let mouse = new THREE.Vector2(
+		((event.clientX - canvasOffset.left) / preview.width) * 2 - 1,
+		-((event.clientY - canvasOffset.top) / preview.height) * 2 + 1
+	);
+	let raycaster = new THREE.Raycaster();
+	raycaster.setFromCamera(mouse, preview.camera);
+	let camDir = new THREE.Vector3();
+	preview.camera.getWorldDirection(camDir);
+	let plane = new THREE.Plane();
+	plane.setFromNormalAndCoplanarPoint(camDir, refPoint);
+	let target = new THREE.Vector3();
+	return raycaster.ray.intersectPlane(plane, target) ? target : null;
+}
+
 export function setupPivotSnap() {
+	let guideLine = new THREE.Line(
+		new THREE.BufferGeometry(),
+		new THREE.LineBasicMaterial({ color: getAccentColor(), depthTest: false, transparent: true })
+	);
+	guideLine.renderOrder = 901;
+	guideLine.frustumCulled = false;
+
+	let sourceMarker = new THREE.Points(
+		new THREE.BufferGeometry(),
+		new THREE.PointsMaterial({
+			size: 7,
+			sizeAttenuation: false,
+			color: getAccentColor(),
+			depthTest: false,
+			transparent: true,
+		})
+	);
+	sourceMarker.renderOrder = 901;
+	sourceMarker.frustumCulled = false;
+
+	function showSourceMarker(pos: THREE.Vector3) {
+		sourceMarker.geometry.setAttribute('position', new THREE.BufferAttribute(
+			new Float32Array(pos.toArray()), 3
+		));
+		Project.model_3d.add(sourceMarker);
+		sourceMarker.position.copy(scene.position).multiplyScalar(-1);
+	}
+
+	function removeSourceMarker() {
+		Project.model_3d.remove(sourceMarker);
+	}
+
+	function removeGuideLine() {
+		Project.model_3d.remove(guideLine);
+	}
+
+	function drawGuideLine(start: THREE.Vector3, end: THREE.Vector3) {
+		guideLine.geometry.setAttribute('position', new THREE.BufferAttribute(
+			new Float32Array([...start.toArray(), ...end.toArray()]), 3
+		));
+		Project.model_3d.add(guideLine);
+		guideLine.position.copy(scene.position).multiplyScalar(-1);
+	}
+
+	function addHoverListener() {
+		let el = $('#preview').get(0);
+		if (el) {
+			el.removeEventListener('mousemove', Vertexsnap.hoverCanvas);
+			el.addEventListener('mousemove', Vertexsnap.hoverCanvas);
+		}
+	}
+
+	// --- Override addVertices ---
 	let originalAddVertices = Vertexsnap.addVertices;
 
 	Vertexsnap.addVertices = function (element: any) {
@@ -130,6 +202,18 @@ export function setupPivotSnap() {
 		}
 	};
 
+	// --- Override clearVertexGizmos ---
+	let originalClearVertexGizmos = Vertexsnap.clearVertexGizmos;
+	Vertexsnap.clearVertexGizmos = function () {
+		removeGuideLine();
+		originalClearVertexGizmos.call(this);
+		// Keep hover listener alive during step 2 so guide line persists across selection changes
+		if (!Vertexsnap.step1) {
+			addHoverListener();
+		}
+	};
+
+	// --- Override canvasClick ---
 	let originalCanvasClick = Vertexsnap.canvasClick;
 	let _parentPivotGroup: any = null;
 
@@ -144,6 +228,8 @@ export function setupPivotSnap() {
 					Vertexsnap.vertex_pos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
 					_parentPivotGroup = parentGroup;
 					Vertexsnap.clearVertexGizmos();
+					showSourceMarker(Vertexsnap.vertex_pos);
+					addHoverListener();
 					$('#preview').css('cursor', 'alias');
 					Blockbench.setStatusBarText();
 					return;
@@ -183,6 +269,8 @@ export function setupPivotSnap() {
 
 			Undo.finishEdit('Use vertex snap');
 
+			removeGuideLine();
+			removeSourceMarker();
 			_parentPivotGroup = null;
 			Vertexsnap.step1 = true;
 			$('#preview').css('cursor', 'copy');
@@ -190,30 +278,79 @@ export function setupPivotSnap() {
 			return;
 		}
 
+		let wasStep1 = Vertexsnap.step1;
 		originalCanvasClick.call(this, data);
-	};
 
-	let originalHoverCanvas = Vertexsnap.hoverCanvas;
-	Vertexsnap.hoverCanvas = function (event: any) {
-		originalHoverCanvas.call(this, event);
-		for (let el of Vertexsnap.elements_with_vertex_gizmos) {
-			let pts = (el as any).mesh?.vertex_points;
-			if (!pts || pts._parent_pivot_index == null) continue;
-			let colorAttr = pts.geometry.attributes.color;
-			if (!colorAttr) continue;
-			let idx = pts._parent_pivot_index * 3;
-			if (idx + 2 >= colorAttr.array.length) continue;
-			let { r, g, b } = gizmo_colors.grid;
-			if (colorAttr.array[idx] === r && colorAttr.array[idx + 1] === g && colorAttr.array[idx + 2] === b) {
-				let accent = getAccentColor();
-				colorAttr.array[idx] = accent.r;
-				colorAttr.array[idx + 1] = accent.g;
-				colorAttr.array[idx + 2] = accent.b;
-				colorAttr.needsUpdate = true;
-			}
+		if (wasStep1 && !Vertexsnap.step1) {
+			// Native step 1 completed: show source marker and re-add hover listener
+			showSourceMarker(Vertexsnap.vertex_pos);
+			addHoverListener();
+		} else if (!wasStep1 && Vertexsnap.step1) {
+			// Native step 2 completed
+			removeGuideLine();
+			removeSourceMarker();
 		}
 	};
 
+	// --- Override hoverCanvas ---
+	let originalHoverCanvas = Vertexsnap.hoverCanvas;
+	Vertexsnap.hoverCanvas = function (event: any) {
+		let data = Canvas.raycast(event);
+
+		// Reset vertex colors and remove lines from previous frame
+		if (Vertexsnap.hovering) {
+			Project.model_3d.remove(Vertexsnap.line);
+			removeGuideLine();
+
+			for (let el of Vertexsnap.elements_with_vertex_gizmos) {
+				let points = (el as any).mesh?.vertex_points;
+				if (!points) continue;
+				let colors: number[] = [];
+				let count = points.geometry.attributes.position.count;
+				for (let i = 0; i < count; i++) {
+					let color;
+					if (data && data.element == el && data.type == 'vertex' && data.vertex_index == i) {
+						color = gizmo_colors.outline;
+					} else if (points._parent_pivot_index != null && i === points._parent_pivot_index) {
+						color = getAccentColor();
+					} else {
+						color = gizmo_colors.grid;
+					}
+					colors.push(color.r, color.g, color.b);
+				}
+				points.material.depthTest = !(data && data.element == el);
+				points.geometry.setAttribute('color', new THREE.Float32BufferAttribute(new Float32Array(colors), 3));
+			}
+		}
+
+		// Guide line from source to cursor/target (step 2)
+		if (!Vertexsnap.step1 && Vertexsnap.vertex_pos) {
+			let endPos: THREE.Vector3 | null = null;
+
+			if (data && data.type === 'vertex') {
+				endPos = Vertexsnap.getGlobalVertexPos(data.element, data.vertex);
+				let diff = new THREE.Vector3().copy(Vertexsnap.vertex_pos).sub(endPos);
+				Blockbench.setStatusBarText(tl('status_bar.vertex_distance', [trimFloatNumber(diff.length())]));
+			} else {
+				endPos = projectMouseToPlane(event, Vertexsnap.vertex_pos);
+			}
+
+			if (endPos) {
+				drawGuideLine(Vertexsnap.vertex_pos, endPos);
+			}
+
+			Vertexsnap.hovering = true;
+			return;
+		}
+
+		if (!data || data.type !== 'vertex') {
+			Blockbench.setStatusBarText();
+			return;
+		}
+		Vertexsnap.hovering = true;
+	};
+
+	// --- Snap mode selector ---
 	let snapTo = new BarSelect('snap_to', {
 		options: {
 			vertex: { name: 'Vertex', icon: 'fiber_manual_record' },
@@ -247,6 +384,13 @@ export function setupPivotSnap() {
 			Vertexsnap.addVertices = originalAddVertices;
 			Vertexsnap.canvasClick = originalCanvasClick;
 			Vertexsnap.hoverCanvas = originalHoverCanvas;
+			Vertexsnap.clearVertexGizmos = originalClearVertexGizmos;
+			removeGuideLine();
+			removeSourceMarker();
+			guideLine.geometry.dispose();
+			(guideLine.material as THREE.LineBasicMaterial).dispose();
+			sourceMarker.geometry.dispose();
+			(sourceMarker.material as THREE.PointsMaterial).dispose();
 		}
 	});
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -22,6 +22,7 @@ import { setupUVCanvasResize } from "./uv_canvas_resize";
 import { setupAltDuplicate } from "./alt_duplicate";
 import { setupChangeOrientation } from "./change_orientation";
 import { setupShortcuts } from "./shortcuts";
+import { setupPivotSnap } from "./pivot_snap";
 
 BBPlugin.register('hytale_plugin', {
     title: 'Hytale Models',
@@ -62,6 +63,7 @@ BBPlugin.register('hytale_plugin', {
         setupPreviewScenes();
         setupUVCanvasResize();
         setupShortcuts();
+        setupPivotSnap();
 
         // Collections panel setting
         let panel_setup_listener: Deletable;


### PR DESCRIPTION
Extended pivot snapping to support edges and faces on top of the existing vertex mode as requested in #25. A `Snap To` dropdown in the toolbar lets artists switch between vertex, edge and face center targets.

Visible guide line is now drawn from the first selected point while picking the second point so artists can see the snap direction before confirming. Pressing ESC after selection cancel the operation. Snap points render through geometry so they are always visible regardless of camera angle.

Pivot snap plane calculation has been fixed when working with rotated groups. Added Esc to cancel mid-snap.