### PR TITLE
Shared texture between attachments

### DIFF
--- a/dist/hytale_plugin.js
+++ b/dist/hytale_plugin.js
@@ -1250,6 +1250,8 @@
     if (newTextures.length === 0) return "";
     for (let tex of newTextures) {
       tex.group = textureGroup.uuid;
+      tex.attachment_texture_groups ??= [];
+      tex.attachment_texture_groups.push(textureGroup.uuid);
       updateUVSize(tex);
     }
     let texture = newTextures.find((t) => t.name.startsWith(attachmentName)) ?? newTextures[0];
@@ -1279,6 +1281,20 @@
     track({
       delete() {
         CubeFace.prototype.getTexture = originalGetTexture;
+      }
+    });
+    new Property(Texture, "array", "attachment_texture_groups");
+    let original_getTextures = TextureGroup.prototype.getTextures;
+    TextureGroup.prototype.getTextures = function() {
+      if (isHytaleFormat()) {
+        return Texture.all.filter((tex) => tex.attachment_texture_groups?.includes(this.uuid));
+      } else {
+        return original_getTextures.call(this);
+      }
+    };
+    track({
+      delete() {
+        TextureGroup.prototype.getTextures = original_getTextures;
       }
     });
     let assignTexture = {
@@ -1348,7 +1364,9 @@
             }
             let texture_group = TextureGroup.all.find((tg) => tg.name === collection.name);
             if (texture_group) {
-              let textures2 = Texture.all.filter((t) => t.group === texture_group.uuid);
+              let textures2 = Texture.all.filter((t) => {
+                return t.group === texture_group.uuid || t.attachment_texture_groups?.includes(texture_group.uuid);
+              });
               textures.safePush(...textures2);
               texture_groups.push(texture_group);
             }
@@ -3515,12 +3533,12 @@ body.hytale-uv-outline-only #uv_frame .cube_uv_face:not(.unselected)::before {
     apply() {
       if (!this.texture) return;
       const selectedTexture = this.texture;
-      const textureGroupUuid = selectedTexture.group;
-      const isAttachmentTexture = !!textureGroupUuid;
+      const textureGroup = selectedTexture.getGroup();
+      const isAttachmentTexture = !!textureGroup;
       let texturesToCrop;
       let elementsToAffect;
       if (isAttachmentTexture) {
-        texturesToCrop = Texture.all.filter((t) => t.group === textureGroupUuid);
+        texturesToCrop = textureGroup.getTextures();
         const relatedCollections = Collection.all.filter((c) => {
           const collectionTexUuid = c.texture;
           return texturesToCrop.some((t) => t.uuid === collectionTexUuid);

--- a/src/attachment_texture.ts
+++ b/src/attachment_texture.ts
@@ -1,6 +1,13 @@
 //! Copyright (C) 2025 Hypixel Studios Canada inc.
 //! Licensed under the GNU General Public License, see LICENSE.MD
 
+declare global {
+	interface Texture {
+		attachment_texture_groups: string[]
+	}
+}
+
+import { CustomMenuItem } from "blockbench-types/generated/interface/menu";
 import { track } from "./cleanup";
 import { FORMAT_IDS, isHytaleFormat } from "./formats";
 import { updateUVSize } from "./texture";
@@ -22,6 +29,8 @@ export function processAttachmentTextures(attachmentName: string, newTextures: T
 
 	for (let tex of newTextures) {
 		tex.group = textureGroup.uuid;
+		tex.attachment_texture_groups ??= [];
+		tex.attachment_texture_groups.push(textureGroup.uuid);
 		updateUVSize(tex);
 	}
 
@@ -55,6 +64,21 @@ export function setupAttachmentTextures() {
 	track({
 		delete() {
 			CubeFace.prototype.getTexture = originalGetTexture;
+		}
+	});
+
+	new Property(Texture, 'array', 'attachment_texture_groups');
+    let original_getTextures = TextureGroup.prototype.getTextures;
+    TextureGroup.prototype.getTextures = function() {
+        if (isHytaleFormat()) {
+			return Texture.all.filter(tex => tex.attachment_texture_groups?.includes(this.uuid));
+        } else {
+            return original_getTextures.call(this)
+        }
+    }
+	track({
+		delete() {
+			TextureGroup.prototype.getTextures = original_getTextures;
 		}
 	});
 

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -36,7 +36,9 @@ export function setupAttachments() {
 					
 					let texture_group = TextureGroup.all.find(tg => tg.name === collection.name);
 					if (texture_group) {
-						let textures2 = Texture.all.filter(t => t.group === texture_group.uuid);
+						let textures2 = Texture.all.filter(t => {
+							return t.group === texture_group.uuid || t.attachment_texture_groups?.includes(texture_group.uuid);
+					});
 						textures.safePush(...textures2);
 						texture_groups.push(texture_group);
 					}

--- a/src/uv_canvas_resize.ts
+++ b/src/uv_canvas_resize.ts
@@ -418,15 +418,15 @@ class UVCropTool {
         const selectedTexture = this.texture;
 
         // Check if this texture belongs to a TextureGroup (attachment textures are grouped)
-        const textureGroupUuid = (selectedTexture as any).group as string | undefined;
-        const isAttachmentTexture = !!textureGroupUuid;
+        const textureGroup = selectedTexture.getGroup();
+        const isAttachmentTexture = !!textureGroup;
 
         let texturesToCrop: Texture[];
         let elementsToAffect: OutlinerElement[];
 
         if (isAttachmentTexture) {
             // Get ALL textures in the same TextureGroup
-            texturesToCrop = Texture.all.filter(t => (t as any).group === textureGroupUuid);
+            texturesToCrop = textureGroup.getTextures();
 
             // Find collections that use any of these textures
             const relatedCollections = Collection.all.filter(c => {
@@ -445,7 +445,7 @@ class UVCropTool {
                 Collection.all.map(c => (c as AttachmentCollection).texture).filter(Boolean)
             );
             texturesToCrop = Texture.all.filter(t =>
-                !(t as any).group && !collectionTextureUuids.has(t.uuid)
+                !t.group && !collectionTextureUuids.has(t.uuid)
             );
             // Affect elements not in any collection
             elementsToAffect = Outliner.elements.filter(el =>


### PR DESCRIPTION
Instead of duplicating a texture and syncing changes between the duplicates, this PR aims to keep it as one texture, but just display it multiple times in the textures list if it's used by multiple texture groups.

Closes #217 and potentially some other issues.